### PR TITLE
Set up Docker build for Python API

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,6 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+# Install system dependencies required by Prisma (needs libatomic for Node.js)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libatomic1 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install dependencies (paths relative to repo root since Railway uses repo root as build context)
 COPY api/pyproject.toml ./
 RUN pip install --no-cache-dir .


### PR DESCRIPTION
The Prisma Python client installs a Node.js binary that requires libatomic.so.1, which is not included in python:3.11-slim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to ensure proper system dependency installation, improving build reliability and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->