### PR TITLE
Fix port conflict between Postgres and Erbase

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         condition: service_healthy
 
   ehrbase-db:
-    image: ehrbase/ehrbase-postgres:16.2
+    image: ehrbase/ehrbase-postgres:16.2-mvp
     ports:
       - "5433:5432"
     environment:

--- a/ehrbase-db/Dockerfile
+++ b/ehrbase-db/Dockerfile
@@ -1,5 +1,5 @@
 # EHRBase PostgreSQL with required extensions
-FROM ehrbase/ehrbase-postgres:16.2
+FROM ehrbase/ehrbase-postgres:16.2-mvp
 
 # Railway provides PORT env var, but postgres uses 5432 internally
 EXPOSE 5432


### PR DESCRIPTION
The ehrbase/ehrbase-postgres:16.2 tag doesn't exist on Docker Hub. Changed to 16.2-mvp which is the actual available tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database image to the MVP release version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->