### PR TITLE
Set up EHRbase Docker build configuration

### DIFF
--- a/ehrbase/Dockerfile
+++ b/ehrbase/Dockerfile
@@ -2,7 +2,7 @@
 FROM ehrbase/ehrbase:2.0.0
 
 # Copy wait-for-db script that ensures PostgreSQL is ready before starting
-COPY wait-for-db.sh /wait-for-db.sh
+COPY ehrbase/wait-for-db.sh /wait-for-db.sh
 RUN chmod +x /wait-for-db.sh
 
 EXPOSE 8080


### PR DESCRIPTION
Railway builds from repo root context but Dockerfile referenced wait-for-db.sh without the ehrbase/ prefix, causing build failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to reference startup script from a new location, ensuring proper initialization process within containerized environments. No changes to runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->