### PR TITLE
Fix wait-for-db.sh script issues

### DIFF
--- a/ehrbase/Dockerfile
+++ b/ehrbase/Dockerfile
@@ -1,9 +1,18 @@
 # EHRBase Clinical Data Repository
 FROM ehrbase/ehrbase:2.0.0
 
+# Install netcat for database connectivity check
+# The base image uses Debian/Ubuntu, so we use apt
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy wait-for-db script that ensures PostgreSQL is ready before starting
 COPY ehrbase/wait-for-db.sh /wait-for-db.sh
 RUN chmod +x /wait-for-db.sh
+
+# Switch back to non-root user if the base image uses one
+USER ehrbase
 
 EXPOSE 8080
 


### PR DESCRIPTION
The ehrbase base image may not have /bin/bash, causing "No such file or directory" errors at container startup.

Changes:
- Use #!/bin/sh shebang for POSIX compatibility
- Replace bash-specific /dev/tcp with netcat (nc) for connectivity check
- Install netcat-openbsd in Dockerfile
- Add dynamic JAR path detection for version flexibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Application now verifies database availability before startup, reducing initialization failures.
  * Enhanced startup process with improved error detection and clearer status messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->