### PR TITLE
Debug failed deployment logs and metrics

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       DB_USER: ehrbase
       DB_PASS: ehrbase
       SECURITY_AUTHTYPE: NONE
+      MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health,info,prometheus
     depends_on:
       ehrbase-db:
         condition: service_healthy

--- a/ehrbase/railway.toml
+++ b/ehrbase/railway.toml
@@ -3,7 +3,7 @@ builder = "DOCKERFILE"
 dockerfilePath = "ehrbase/Dockerfile"
 
 [deploy]
-healthcheckPath = "/management/health"
+healthcheckPath = "/ehrbase/management/health"
 # EHRBase is a Spring Boot app that needs 2-3 minutes to start
 # (JVM warmup + Flyway migrations on first run)
 healthcheckTimeout = 300


### PR DESCRIPTION
- Add MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE env var to expose actuator health endpoints (was exposing 0 endpoints)
- Fix health check path from /management/health to /ehrbase/management/health to account for Spring Boot context path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment health check endpoint path for subpath routing
  * Added management endpoints exposure configuration to include health, info, and prometheus endpoints

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->