### PR TITLE
Set up EHRbase Docker build configuration

### DIFF
--- a/ehrbase/Dockerfile
+++ b/ehrbase/Dockerfile
@@ -2,10 +2,9 @@
 FROM ehrbase/ehrbase:2.0.0
 
 # Install netcat for database connectivity check
-# The base image uses Debian/Ubuntu, so we use apt
+# The base image uses Alpine Linux, so we use apk
 USER root
-RUN apt-get update && apt-get install -y --no-install-recommends netcat-openbsd \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache netcat-openbsd
 
 # Copy wait-for-db script that ensures PostgreSQL is ready before starting
 COPY ehrbase/wait-for-db.sh /wait-for-db.sh


### PR DESCRIPTION
The EHRbase base image uses Alpine Linux, not Debian/Ubuntu. Changed package manager command from apt-get to apk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image build and deployment efficiency through updated package management approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->