### PR TITLE
feat: Add OIDC authentication with Dex and role-based access control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ CORS_ORIGINS=["http://localhost:5173"]
 
 # OIDC - for API service
 OIDC_ISSUER=http://localhost:5556/dex
+OIDC_CLIENT_ID=open-cis-web
 
 # Frontend - for web service
 VITE_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,18 @@ EHRBASE_PASSWORD=
 # CORS origins - for API service (JSON array)
 CORS_ORIGINS=["http://localhost:5173"]
 
+# OIDC - for API service
+OIDC_ISSUER=http://localhost:5556/dex
+
 # Frontend - for web service
 VITE_API_URL=http://localhost:8000
+VITE_OIDC_ISSUER=http://localhost:5556/dex
+VITE_OIDC_CLIENT_ID=open-cis-web
+# VITE_APP_MODE=demo  # Set to 'demo' to show demo credentials on login page
+
+# Dex demo password hashes (bcrypt)
+DEX_DEMO_ADMIN_HASH=$2b$10$0ZIL.9k.bCmO9SS.8hOFreuX32kXoTeAMQnUlPeX83aQwmB4/7VdC
+DEX_DEMO_CLINICIAN_HASH=$2b$10$dnqTBcl8.TMjpfcb7gsZGujBC/HMLxuExPcK4MaVKUwonsK6b9CPm
 
 # ============================================
 # EHRBase Database (ehrbase-db service)

--- a/api/prisma/migrations/20260406000000_add_external_id_to_user/migration.sql
+++ b/api/prisma/migrations/20260406000000_add_external_id_to_user/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "externalId" TEXT;
+
+-- Backfill existing rows with a unique placeholder
+UPDATE "User" SET "externalId" = 'legacy-' || "id" WHERE "externalId" IS NULL;
+
+-- Make the column required and unique
+ALTER TABLE "User" ALTER COLUMN "externalId" SET NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_externalId_key" ON "User"("externalId");

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -10,13 +10,14 @@ generator client {
 }
 
 model User {
-  id        String     @id @default(cuid())
-  email     String     @unique
-  name      String
-  role      Role       @default(CLINICIAN)
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
-  auditLogs AuditLog[]
+  id         String     @id @default(cuid())
+  externalId String     @unique
+  email      String     @unique
+  name       String
+  role       Role       @default(CLINICIAN)
+  createdAt  DateTime   @default(now())
+  updatedAt  DateTime   @updatedAt
+  auditLogs  AuditLog[]
 }
 
 model AuditLog {

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "aiofiles>=23.2.0",
     "faker>=22.0.0",
     "oehrpy>=0.7.0",
+    "python-jose[cryptography]>=3.3.0",
 ]
 
 [project.optional-dependencies]
@@ -41,7 +42,7 @@ target-version = "py311"
 select = ["E", "F", "I", "UP", "B"]
 
 [tool.ruff.lint.flake8-bugbear]
-extend-immutable-calls = ["fastapi.Query", "fastapi.Depends", "fastapi.Path"]
+extend-immutable-calls = ["fastapi.Query", "fastapi.Depends", "fastapi.Path", "src.auth.permissions.require_role", "require_role"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/api/src/audit/service.py
+++ b/api/src/audit/service.py
@@ -1,5 +1,6 @@
 import logging
 
+from prisma import Json
 from src.db.client import prisma
 
 logger = logging.getLogger(__name__)
@@ -22,8 +23,8 @@ async def log_action(
                 "resource": resource,
                 "resourceId": resource_id,
                 "ehrId": ehr_id,
-                "metadata": metadata,  # type: ignore[typeddict-item]  # Prisma Json type
+                "metadata": Json(metadata) if metadata is not None else None,
             }
         )
-    except Exception as e:
-        logger.error(f"Failed to write audit log: {e}")
+    except Exception:
+        logger.exception("Failed to write audit log")

--- a/api/src/audit/service.py
+++ b/api/src/audit/service.py
@@ -1,0 +1,29 @@
+import logging
+
+from src.db.client import prisma
+
+logger = logging.getLogger(__name__)
+
+
+async def log_action(
+    user_id: str,
+    action: str,
+    resource: str,
+    resource_id: str | None = None,
+    ehr_id: str | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """Write an audit log entry for a mutating operation."""
+    try:
+        await prisma.auditlog.create(
+            data={
+                "userId": user_id,
+                "action": action,
+                "resource": resource,
+                "resourceId": resource_id,
+                "ehrId": ehr_id,
+                "metadata": metadata,
+            }
+        )
+    except Exception as e:
+        logger.error(f"Failed to write audit log: {e}")

--- a/api/src/audit/service.py
+++ b/api/src/audit/service.py
@@ -22,7 +22,7 @@ async def log_action(
                 "resource": resource,
                 "resourceId": resource_id,
                 "ehrId": ehr_id,
-                "metadata": metadata,
+                "metadata": metadata,  # type: ignore[typeddict-item]  # Prisma Json type
             }
         )
     except Exception as e:

--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -77,7 +77,7 @@ async def get_current_user(
                 "externalId": sub,
                 "email": email,
                 "name": name,
-                "role": "CLINICIAN",
+                "role": "CLINICIAN",  # type: ignore[typeddict-item]  # Prisma accepts string for enum
             },
             "update": {
                 "email": email,

--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -92,11 +92,12 @@ async def get_current_user(
     if email:
         existing = await prisma.user.find_unique(where={"email": email})
         if existing is not None:
-            user = await prisma.user.update(
+            updated = await prisma.user.update(
                 where={"id": existing.id},
                 data={"externalId": sub, "name": name},
             )
-            return user
+            if updated is not None:
+                return updated
 
     # Brand-new user
     user = await prisma.user.create(

--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -5,6 +5,7 @@ import httpx
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
+from prisma.enums import Role
 from prisma.models import User
 
 from src.config import settings
@@ -74,13 +75,19 @@ async def get_current_user(
         ) from e
 
     sub: str | None = payload.get("sub")
-    email: str = payload.get("email", "")
-    name: str = payload.get("name", email)
+    email: str | None = payload.get("email")
+    name: str = payload.get("name", email or sub or "")
 
     if not sub:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token missing sub claim",
+        )
+
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing email claim",
         )
 
     # Read-then-create: avoid writes on read paths
@@ -89,23 +96,31 @@ async def get_current_user(
         return user
 
     # First login — check if a legacy user with this email exists (migration)
-    if email:
-        existing = await prisma.user.find_unique(where={"email": email})
-        if existing is not None:
-            updated = await prisma.user.update(
-                where={"id": existing.id},
-                data={"externalId": sub, "name": name},
-            )
-            if updated is not None:
-                return updated
+    existing = await prisma.user.find_unique(where={"email": email})
+    if existing is not None and existing.externalId.startswith("legacy-"):
+        updated = await prisma.user.update(
+            where={"id": existing.id},
+            data={"externalId": sub, "name": name},
+        )
+        if updated is not None:
+            return updated
 
-    # Brand-new user
-    user = await prisma.user.create(
-        data={
-            "externalId": sub,
-            "email": email,
-            "name": name,
-            "role": "CLINICIAN",  # type: ignore[typeddict-item]
-        }
-    )
+    # Brand-new user — guard against unique constraint race
+    try:
+        user = await prisma.user.create(
+            data={
+                "externalId": sub,
+                "email": email,
+                "name": name,
+                "role": Role.CLINICIAN,
+            }
+        )
+    except Exception as e:
+        # Race condition: another request created the user first
+        user = await prisma.user.find_unique(where={"externalId": sub})
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create user account",
+            ) from e
     return user

--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -1,10 +1,11 @@
 import logging
-from functools import lru_cache
+import time
 
 import httpx
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
+from prisma.models import User
 
 from src.config import settings
 from src.db.client import prisma
@@ -13,38 +14,51 @@ logger = logging.getLogger(__name__)
 
 security = HTTPBearer()
 
+# JWKS cache with TTL
+_jwks_cache: dict | None = None
+_jwks_cache_time: float = 0
+_JWKS_TTL_SECONDS = 3600  # 1 hour
 
-@lru_cache(maxsize=1)
-def _get_oidc_config() -> dict:
-    """Fetch OIDC discovery document (cached)."""
+
+async def _get_oidc_config() -> dict:
+    """Fetch OIDC discovery document."""
     discovery_url = f"{settings.oidc_issuer}/.well-known/openid-configuration"
-    response = httpx.get(discovery_url, timeout=10)
-    response.raise_for_status()
-    return response.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.get(discovery_url, timeout=10)
+        response.raise_for_status()
+        return response.json()
 
 
-@lru_cache(maxsize=1)
-def _get_jwks() -> dict:
-    """Fetch JWKS from the OIDC provider (cached)."""
-    config = _get_oidc_config()
+async def _get_jwks() -> dict:
+    """Fetch JWKS from the OIDC provider with TTL-based caching."""
+    global _jwks_cache, _jwks_cache_time
+
+    now = time.monotonic()
+    if _jwks_cache is not None and (now - _jwks_cache_time) < _JWKS_TTL_SECONDS:
+        return _jwks_cache
+
+    config = await _get_oidc_config()
     jwks_uri = config["jwks_uri"]
-    response = httpx.get(jwks_uri, timeout=10)
-    response.raise_for_status()
-    return response.json()
+    async with httpx.AsyncClient() as client:
+        response = await client.get(jwks_uri, timeout=10)
+        response.raise_for_status()
+        _jwks_cache = response.json()
+        _jwks_cache_time = now
+        return _jwks_cache  # type: ignore[return-value]
 
 
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials = Depends(security),
-):
+) -> User:
     """Validate JWT Bearer token and return the authenticated User."""
     token = credentials.credentials
     try:
-        jwks = _get_jwks()
+        jwks = await _get_jwks()
         payload = jwt.decode(
             token,
             jwks,
             algorithms=["RS256"],
-            options={"verify_aud": False},
+            audience=settings.oidc_client_id,
         )
     except JWTError as e:
         logger.debug(f"JWT validation failed: {e}")
@@ -59,9 +73,9 @@ async def get_current_user(
             detail="Could not validate credentials",
         ) from e
 
-    sub = payload.get("sub")
-    email = payload.get("email", "")
-    name = payload.get("name", email)
+    sub: str | None = payload.get("sub")
+    email: str = payload.get("email", "")
+    name: str = payload.get("name", email)
 
     if not sub:
         raise HTTPException(
@@ -69,20 +83,28 @@ async def get_current_user(
             detail="Token missing sub claim",
         )
 
-    # Upsert user on first login
-    user = await prisma.user.upsert(
-        where={"externalId": sub},
+    # Read-then-create: avoid writes on read paths
+    user = await prisma.user.find_unique(where={"externalId": sub})
+    if user is not None:
+        return user
+
+    # First login — check if a legacy user with this email exists (migration)
+    if email:
+        existing = await prisma.user.find_unique(where={"email": email})
+        if existing is not None:
+            user = await prisma.user.update(
+                where={"id": existing.id},
+                data={"externalId": sub, "name": name},
+            )
+            return user
+
+    # Brand-new user
+    user = await prisma.user.create(
         data={
-            "create": {
-                "externalId": sub,
-                "email": email,
-                "name": name,
-                "role": "CLINICIAN",  # type: ignore[typeddict-item]  # Prisma accepts string for enum
-            },
-            "update": {
-                "email": email,
-                "name": name,
-            },
-        },
+            "externalId": sub,
+            "email": email,
+            "name": name,
+            "role": "CLINICIAN",  # type: ignore[typeddict-item]
+        }
     )
     return user

--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -1,0 +1,88 @@
+import logging
+from functools import lru_cache
+
+import httpx
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import JWTError, jwt
+
+from src.config import settings
+from src.db.client import prisma
+
+logger = logging.getLogger(__name__)
+
+security = HTTPBearer()
+
+
+@lru_cache(maxsize=1)
+def _get_oidc_config() -> dict:
+    """Fetch OIDC discovery document (cached)."""
+    discovery_url = f"{settings.oidc_issuer}/.well-known/openid-configuration"
+    response = httpx.get(discovery_url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+@lru_cache(maxsize=1)
+def _get_jwks() -> dict:
+    """Fetch JWKS from the OIDC provider (cached)."""
+    config = _get_oidc_config()
+    jwks_uri = config["jwks_uri"]
+    response = httpx.get(jwks_uri, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+):
+    """Validate JWT Bearer token and return the authenticated User."""
+    token = credentials.credentials
+    try:
+        jwks = _get_jwks()
+        payload = jwt.decode(
+            token,
+            jwks,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+        )
+    except JWTError as e:
+        logger.debug(f"JWT validation failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        ) from e
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"OIDC validation error: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        ) from e
+
+    sub = payload.get("sub")
+    email = payload.get("email", "")
+    name = payload.get("name", email)
+
+    if not sub:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token missing sub claim",
+        )
+
+    # Upsert user on first login
+    user = await prisma.user.upsert(
+        where={"externalId": sub},
+        data={
+            "create": {
+                "externalId": sub,
+                "email": email,
+                "name": name,
+                "role": "CLINICIAN",
+            },
+            "update": {
+                "email": email,
+                "name": name,
+            },
+        },
+    )
+    return user

--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -43,9 +43,10 @@ async def _get_jwks() -> dict:
     async with httpx.AsyncClient() as client:
         response = await client.get(jwks_uri, timeout=10)
         response.raise_for_status()
-        _jwks_cache = response.json()
+        jwks: dict = response.json()
+        _jwks_cache = jwks
         _jwks_cache_time = now
-        return _jwks_cache  # type: ignore[return-value]
+        return jwks
 
 
 async def get_current_user(

--- a/api/src/auth/permissions.py
+++ b/api/src/auth/permissions.py
@@ -1,11 +1,12 @@
 from fastapi import Depends, HTTPException, status
+from prisma.models import User
 
 from src.auth.dependencies import get_current_user
 
 
 def require_role(*allowed_roles: str):
     """Dependency that checks the current user has one of the allowed roles."""
-    async def dependency(current_user=Depends(get_current_user)):
+    async def dependency(current_user: User = Depends(get_current_user)) -> User:
         if current_user.role not in allowed_roles:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,

--- a/api/src/auth/permissions.py
+++ b/api/src/auth/permissions.py
@@ -1,0 +1,15 @@
+from fastapi import Depends, HTTPException, status
+
+from src.auth.dependencies import get_current_user
+
+
+def require_role(*allowed_roles: str):
+    """Dependency that checks the current user has one of the allowed roles."""
+    async def dependency(current_user=Depends(get_current_user)):
+        if current_user.role not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient permissions",
+            )
+        return current_user
+    return Depends(dependency)

--- a/api/src/auth/router.py
+++ b/api/src/auth/router.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+
+from src.auth.dependencies import get_current_user
+from src.auth.schemas import UserResponse
+
+router = APIRouter()
+
+
+@router.get("/me", response_model=UserResponse)
+async def get_me(current_user=Depends(get_current_user)) -> UserResponse:
+    """Return the current authenticated user's profile."""
+    return UserResponse.model_validate(current_user)

--- a/api/src/auth/router.py
+++ b/api/src/auth/router.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends
+from prisma.models import User
 
 from src.auth.dependencies import get_current_user
 from src.auth.schemas import UserResponse
@@ -7,6 +8,6 @@ router = APIRouter()
 
 
 @router.get("/me", response_model=UserResponse)
-async def get_me(current_user=Depends(get_current_user)) -> UserResponse:
+async def get_me(current_user: User = Depends(get_current_user)) -> UserResponse:
     """Return the current authenticated user's profile."""
     return UserResponse.model_validate(current_user)

--- a/api/src/auth/schemas.py
+++ b/api/src/auth/schemas.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+
+
+class UserResponse(BaseModel):
+    id: str
+    email: str
+    name: str
+    role: str
+
+    model_config = {"from_attributes": True}

--- a/api/src/cave/router.py
+++ b/api/src/cave/router.py
@@ -1,7 +1,10 @@
 """Router for CAVE (allergies & adverse reactions)."""
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from src.audit.service import log_action
+from src.auth.dependencies import get_current_user
+from src.auth.permissions import require_role
 from src.cave.schemas import (
     CaveEntryCreate,
     CaveEntryResponse,
@@ -18,12 +21,22 @@ router = APIRouter()
 
 
 @router.post("", response_model=CaveEntryResponse, status_code=201)
-async def create_cave_entry(data: CaveEntryCreate) -> CaveEntryResponse:
+async def create_cave_entry(
+    data: CaveEntryCreate,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+) -> CaveEntryResponse:
     """Create a new CAVE entry (allergy/adverse reaction).
 
     Creates a composition in EHRBase with the adverse reaction data.
     """
-    return await cave_service.create_cave_entry(data)
+    result = await cave_service.create_cave_entry(data)
+    await log_action(
+        user_id=current_user.id,
+        action="CREATE",
+        resource="CaveEntry",
+        resource_id=result.composition_uid,
+    )
+    return result
 
 
 @router.get("", response_model=CaveListResponse)
@@ -31,6 +44,7 @@ async def list_cave_entries(
     patient_id: str = Query(..., description="Patient ID (required)"),
     status: str | None = Query(None, description="Filter by status"),
     category: str | None = Query(None, description="Filter by category"),
+    current_user=Depends(get_current_user),
 ) -> CaveListResponse:
     """List CAVE entries for a patient."""
     return await cave_service.get_cave_entries(
@@ -41,7 +55,9 @@ async def list_cave_entries(
 
 
 @router.get("/summary/{patient_id}", response_model=CaveSummaryResponse)
-async def get_cave_summary(patient_id: str) -> CaveSummaryResponse:
+async def get_cave_summary(
+    patient_id: str, current_user=Depends(get_current_user),
+) -> CaveSummaryResponse:
     """Get CAVE summary for the patient banner.
 
     Returns active allergy count, high criticality flag, and NKA status.
@@ -53,6 +69,7 @@ async def get_cave_summary(patient_id: str) -> CaveSummaryResponse:
 async def get_cave_entry(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
+    current_user=Depends(get_current_user),
 ) -> CaveEntryResponse:
     """Get a single CAVE entry by composition UID."""
     result = await cave_service.get_cave_entry(composition_uid, patient_id)
@@ -66,23 +83,40 @@ async def update_cave_entry(
     composition_uid: str,
     data: CaveEntryUpdate,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
 ) -> CaveEntryResponse:
     """Update a CAVE entry (criticality, status, reactions, comment)."""
     result = await cave_service.update_cave_entry(composition_uid, patient_id, data)
     if not result:
         raise HTTPException(status_code=404, detail="CAVE entry not found")
+    await log_action(
+        user_id=current_user.id,
+        action="UPDATE",
+        resource="CaveEntry",
+        resource_id=composition_uid,
+    )
     return result
 
 
 @router.post("/nka", response_model=NkaResponse, status_code=201)
-async def record_nka(data: NkaRequest) -> NkaResponse:
+async def record_nka(
+    data: NkaRequest,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+) -> NkaResponse:
     """Record 'No Known Allergies' for a patient."""
-    return await cave_service.record_nka(data)
+    result = await cave_service.record_nka(data)
+    await log_action(
+        user_id=current_user.id,
+        action="CREATE",
+        resource="NKA",
+    )
+    return result
 
 
 @router.delete("/nka", status_code=204)
 async def remove_nka(
     patient_id: str = Query(..., description="Patient ID"),
+    current_user=require_role("ADMIN", "CLINICIAN"),
 ) -> None:
     """Remove 'No Known Allergies' declaration for a patient."""
     success = await cave_service.remove_nka(patient_id)
@@ -90,12 +124,18 @@ async def remove_nka(
         raise HTTPException(
             status_code=404, detail="No NKA declaration found for this patient"
         )
+    await log_action(
+        user_id=current_user.id,
+        action="DELETE",
+        resource="NKA",
+    )
 
 
 @router.delete("/{composition_uid}", status_code=204)
 async def delete_cave_entry(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
+    current_user=require_role("ADMIN", "CLINICIAN"),
 ) -> None:
     """Delete a CAVE entry composition."""
     success = await cave_service.delete_cave_entry(composition_uid, patient_id)
@@ -103,10 +143,16 @@ async def delete_cave_entry(
         raise HTTPException(
             status_code=404, detail="CAVE entry not found or delete failed"
         )
+    await log_action(
+        user_id=current_user.id,
+        action="DELETE",
+        resource="CaveEntry",
+        resource_id=composition_uid,
+    )
 
 
 @router.get("/debug/webtemplate")
-async def debug_webtemplate() -> dict:
+async def debug_webtemplate(current_user=Depends(get_current_user)) -> dict:
     """Debug endpoint: show web template paths and FLAT example for CAVE template.
 
     Returns the web template tree (with FLAT IDs) and an example FLAT composition

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
 
     # OIDC
     oidc_issuer: str = "http://localhost:5556/dex"
+    oidc_client_id: str = "open-cis-web"
 
     # EHRBase (oehrpy client configuration)
     ehrbase_url: str = "http://localhost:8080/ehrbase"

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -12,6 +12,9 @@ class Settings(BaseSettings):
     # Database (Prisma)
     database_url: str = "postgresql://cis:cis@localhost:5432/cis"
 
+    # OIDC
+    oidc_issuer: str = "http://localhost:5556/dex"
+
     # EHRBase (oehrpy client configuration)
     ehrbase_url: str = "http://localhost:8080/ehrbase"
     ehrbase_user: str | None = None

--- a/api/src/ehrbase/client.py
+++ b/api/src/ehrbase/client.py
@@ -8,8 +8,8 @@ import logging
 from typing import Any
 
 import httpx
-from openehr_sdk.client import EHRBaseClient as OehrpyClient
-from openehr_sdk.client import EHRBaseError
+from oehrpy.client import EHRBaseClient as OehrpyClient
+from oehrpy.client import EHRBaseError
 
 from src.config import settings
 from src.errors import EHRBaseUnavailableError, EHRBaseValidationError

--- a/api/src/ehrbase/templates.py
+++ b/api/src/ehrbase/templates.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import aiofiles
 import httpx
-from openehr_sdk.client import EHRBaseError
+from oehrpy.client import EHRBaseError
 
 from src.ehrbase.client import ehrbase_client
 

--- a/api/src/encounters/router.py
+++ b/api/src/encounters/router.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 
+from src.audit.service import log_action
+from src.auth.dependencies import get_current_user
+from src.auth.permissions import require_role
 from src.encounters.schemas import (
     EncounterCreate,
     EncounterResponse,
@@ -12,12 +15,22 @@ router = APIRouter()
 
 
 @router.post("", response_model=EncounterResponse, status_code=201)
-async def create_encounter(data: EncounterCreate):
+async def create_encounter(
+    data: EncounterCreate,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+):
     """Create a new encounter."""
     try:
-        return await encounter_service.create_encounter(data)
+        encounter = await encounter_service.create_encounter(data)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    await log_action(
+        user_id=current_user.id,
+        action="CREATE",
+        resource="Encounter",
+        resource_id=encounter.id,
+    )
+    return encounter
 
 
 @router.get("", response_model=list[EncounterResponse])
@@ -27,6 +40,7 @@ async def list_encounters(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     include_deleted: bool = Query(False, description="Include soft-deleted encounters"),
+    current_user=Depends(get_current_user),
 ):
     """List encounters with optional filtering."""
     return await encounter_service.list_encounters(
@@ -39,7 +53,7 @@ async def list_encounters(
 
 
 @router.get("/{encounter_id}", response_model=EncounterResponse)
-async def get_encounter(encounter_id: str):
+async def get_encounter(encounter_id: str, current_user=Depends(get_current_user)):
     """Get an encounter by ID."""
     encounter = await encounter_service.get_encounter(encounter_id)
     if not encounter:
@@ -48,21 +62,40 @@ async def get_encounter(encounter_id: str):
 
 
 @router.patch("/{encounter_id}", response_model=EncounterResponse)
-async def update_encounter(encounter_id: str, data: EncounterUpdate):
+async def update_encounter(
+    encounter_id: str,
+    data: EncounterUpdate,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+):
     """Update an encounter."""
     try:
         encounter = await encounter_service.update_encounter(encounter_id, data)
         if not encounter:
             raise HTTPException(status_code=404, detail="Encounter not found")
-        return encounter
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    await log_action(
+        user_id=current_user.id,
+        action="UPDATE",
+        resource="Encounter",
+        resource_id=encounter_id,
+    )
+    return encounter
 
 
 @router.delete("/{encounter_id}", status_code=204)
-async def delete_encounter(encounter_id: str):
+async def delete_encounter(
+    encounter_id: str,
+    current_user=require_role("ADMIN", "CLINICIAN"),
+):
     """Soft delete an encounter."""
     deleted = await encounter_service.delete_encounter(encounter_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Encounter not found")
+    await log_action(
+        user_id=current_user.id,
+        action="DELETE",
+        resource="Encounter",
+        resource_id=encounter_id,
+    )
     return Response(status_code=204)

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+from src.auth.router import router as auth_router
 from src.cave.router import router as cave_router
 from src.config import settings
 from src.db.client import prisma
@@ -84,6 +85,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(auth_router, prefix="/api/auth", tags=["auth"])
 app.include_router(patients_router, prefix="/api/patients", tags=["patients"])
 app.include_router(encounters_router, prefix="/api/encounters", tags=["encounters"])
 app.include_router(observations_router, prefix="/api/observations", tags=["observations"])

--- a/api/src/observations/router.py
+++ b/api/src/observations/router.py
@@ -3,8 +3,11 @@
 from datetime import datetime
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
+from src.audit.service import log_action
+from src.auth.dependencies import get_current_user
+from src.auth.permissions import require_role
 from src.ehrbase.client import ehrbase_client
 from src.observations.schemas import (
     RawCompositionResponse,
@@ -25,13 +28,23 @@ router = APIRouter()
 
 
 @router.post("/vital-signs", response_model=VitalSignsResponse, status_code=201)
-async def record_vital_signs(data: VitalSignsCreate) -> VitalSignsResponse:
+async def record_vital_signs(
+    data: VitalSignsCreate,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+) -> VitalSignsResponse:
     """Record vital signs for a patient.
 
     Creates a composition in EHRBase with the vital signs data.
     Returns the recorded data with openEHR metadata for transparency.
     """
-    return await observation_service.record_vital_signs(data)
+    result = await observation_service.record_vital_signs(data)
+    await log_action(
+        user_id=current_user.id,
+        action="CREATE",
+        resource="VitalSigns",
+        resource_id=result.composition_uid,
+    )
+    return result
 
 
 @router.get("/vital-signs", response_model=VitalSignsListResponse)
@@ -41,6 +54,7 @@ async def list_vital_signs(
     to_date: datetime | None = Query(None, description="End of date range"),
     skip: int = Query(0, ge=0, description="Pagination offset"),
     limit: int = Query(100, ge=1, le=1000, description="Page size"),
+    current_user=Depends(get_current_user),
 ) -> VitalSignsListResponse:
     """List vital signs for a patient.
 
@@ -59,6 +73,7 @@ async def list_vital_signs(
 async def get_vital_signs(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
+    current_user=Depends(get_current_user),
 ) -> VitalSignsResponse:
     """Get a single vital signs reading by composition UID."""
     result = await observation_service.get_vital_signs(composition_uid, patient_id)
@@ -71,11 +86,18 @@ async def get_vital_signs(
 async def delete_vital_signs(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
+    current_user=require_role("ADMIN", "CLINICIAN"),
 ) -> None:
     """Delete a vital signs composition."""
     success = await observation_service.delete_vital_signs(composition_uid, patient_id)
     if not success:
         raise HTTPException(status_code=404, detail="Vital signs not found or delete failed")
+    await log_action(
+        user_id=current_user.id,
+        action="DELETE",
+        resource="VitalSigns",
+        resource_id=composition_uid,
+    )
 
 
 # ============================================================================
@@ -84,7 +106,7 @@ async def delete_vital_signs(
 
 
 @router.get("/openehr/templates", response_model=TemplateListResponse)
-async def list_templates() -> TemplateListResponse:
+async def list_templates(current_user=Depends(get_current_user)) -> TemplateListResponse:
     """List all available operational templates in EHRBase."""
     templates = await ehrbase_client.list_templates()
     return TemplateListResponse(
@@ -100,7 +122,7 @@ async def list_templates() -> TemplateListResponse:
 
 
 @router.get("/openehr/templates/{template_id}")
-async def get_template_info(template_id: str) -> dict:
+async def get_template_info(template_id: str, current_user=Depends(get_current_user)) -> dict:
     """Get detailed information about a template.
 
     Returns the template structure with example paths.
@@ -114,7 +136,7 @@ async def get_template_info(template_id: str) -> dict:
 
 
 @router.get("/openehr/templates/{template_id}/webtemplate")
-async def get_web_template(template_id: str) -> dict:
+async def get_web_template(template_id: str, current_user=Depends(get_current_user)) -> dict:
     """Get the web template JSON showing all valid FLAT paths.
 
     Useful for debugging FLAT format composition building issues.
@@ -148,6 +170,7 @@ async def get_raw_composition(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
     format: Literal["FLAT", "STRUCTURED"] = Query("FLAT", description="Composition format"),
+    current_user=Depends(get_current_user),
 ) -> RawCompositionResponse:
     """Get raw composition data for transparency.
 
@@ -165,6 +188,7 @@ async def get_raw_composition(
 async def get_composition_paths(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
+    current_user=Depends(get_current_user),
 ) -> dict:
     """Get all paths in a composition for transparency.
 
@@ -196,7 +220,7 @@ async def get_composition_paths(
 
 
 @router.get("/openehr/archetypes/{archetype_id}")
-async def get_archetype_info(archetype_id: str) -> dict:
+async def get_archetype_info(archetype_id: str, current_user=Depends(get_current_user)) -> dict:
     """Get information about an archetype.
 
     Provides archetype details and link to Clinical Knowledge Manager (CKM).

--- a/api/src/observations/router.py
+++ b/api/src/observations/router.py
@@ -42,7 +42,7 @@ async def record_vital_signs(
         user_id=current_user.id,
         action="CREATE",
         resource="VitalSigns",
-        resource_id=result.composition_uid,
+        resource_id=result.id,
     )
     return result
 

--- a/api/src/openehr/compositions.py
+++ b/api/src/openehr/compositions.py
@@ -3,7 +3,7 @@
 from datetime import UTC, datetime
 from typing import Any
 
-from openehr_sdk.templates import VitalSignsBuilder
+from oehrpy.templates import VitalSignsBuilder
 
 # VitalSignsBuilder FLAT path constants are sourced from the Web Template:
 #   IDCR - Vital Signs Encounter.v1

--- a/api/src/patients/router.py
+++ b/api/src/patients/router.py
@@ -1,6 +1,9 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import Response
 
+from src.audit.service import log_action
+from src.auth.dependencies import get_current_user
+from src.auth.permissions import require_role
 from src.patients.schemas import (
     MrnExistsResponse,
     PatientCreate,
@@ -13,9 +16,20 @@ router = APIRouter()
 
 
 @router.post("", response_model=PatientResponse, status_code=201)
-async def create_patient(data: PatientCreate):
+async def create_patient(
+    data: PatientCreate,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+):
     """Create a new patient."""
-    return await patient_service.create_patient(data)
+    patient = await patient_service.create_patient(data)
+    await log_action(
+        user_id=current_user.id,
+        action="CREATE",
+        resource="Patient",
+        resource_id=patient.id,
+        ehr_id=patient.ehrId,
+    )
+    return patient
 
 
 @router.get("", response_model=list[PatientResponse])
@@ -23,6 +37,7 @@ async def list_patients(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     include_deleted: bool = Query(False, description="Include soft-deleted patients"),
+    current_user=Depends(get_current_user),
 ):
     """List all patients (excludes soft-deleted by default)."""
     return await patient_service.list_patients(
@@ -31,14 +46,14 @@ async def list_patients(
 
 
 @router.get("/mrn/{mrn}/exists", response_model=MrnExistsResponse)
-async def check_mrn_exists(mrn: str):
+async def check_mrn_exists(mrn: str, current_user=Depends(get_current_user)):
     """Check if MRN already exists (for validation)."""
     exists = await patient_service.mrn_exists(mrn)
     return MrnExistsResponse(exists=exists)
 
 
 @router.get("/{patient_id}", response_model=PatientResponse)
-async def get_patient(patient_id: str):
+async def get_patient(patient_id: str, current_user=Depends(get_current_user)):
     """Get a patient by ID."""
     patient = await patient_service.get_patient(patient_id)
     if not patient:
@@ -47,7 +62,7 @@ async def get_patient(patient_id: str):
 
 
 @router.get("/mrn/{mrn}", response_model=PatientResponse)
-async def get_patient_by_mrn(mrn: str):
+async def get_patient_by_mrn(mrn: str, current_user=Depends(get_current_user)):
     """Get a patient by MRN."""
     patient = await patient_service.get_patient_by_mrn(mrn)
     if not patient:
@@ -56,18 +71,37 @@ async def get_patient_by_mrn(mrn: str):
 
 
 @router.patch("/{patient_id}", response_model=PatientResponse)
-async def update_patient(patient_id: str, data: PatientUpdate):
+async def update_patient(
+    patient_id: str,
+    data: PatientUpdate,
+    current_user=require_role("ADMIN", "CLINICIAN", "NURSE"),
+):
     """Update a patient."""
     patient = await patient_service.update_patient(patient_id, data)
     if not patient:
         raise HTTPException(status_code=404, detail="Patient not found")
+    await log_action(
+        user_id=current_user.id,
+        action="UPDATE",
+        resource="Patient",
+        resource_id=patient_id,
+    )
     return patient
 
 
 @router.delete("/{patient_id}", status_code=204)
-async def delete_patient(patient_id: str):
-    """Soft delete a patient."""
+async def delete_patient(
+    patient_id: str,
+    current_user=require_role("ADMIN"),
+):
+    """Soft delete a patient. Requires ADMIN role."""
     deleted = await patient_service.delete_patient(patient_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Patient not found")
+    await log_action(
+        user_id=current_user.id,
+        action="DELETE",
+        resource="Patient",
+        resource_id=patient_id,
+    )
     return Response(status_code=204)

--- a/api/src/patients/router.py
+++ b/api/src/patients/router.py
@@ -27,7 +27,7 @@ async def create_patient(
         action="CREATE",
         resource="Patient",
         resource_id=patient.id,
-        ehr_id=patient.ehrId,
+        ehr_id=patient.ehr_id,
     )
     return patient
 

--- a/api/src/system/router.py
+++ b/api/src/system/router.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from src.auth.dependencies import get_current_user
 from src.system.schemas import SystemInfoResponse
 from src.system.service import system_service
 
@@ -7,6 +8,6 @@ router = APIRouter()
 
 
 @router.get("", response_model=SystemInfoResponse)
-async def get_system_info() -> SystemInfoResponse:
+async def get_system_info(current_user=Depends(get_current_user)) -> SystemInfoResponse:
     """Get system health, versions, registered templates, and data statistics."""
     return await system_service.get_system_info()

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,21 +1,50 @@
 """Pytest fixtures for API tests."""
 
+from unittest.mock import MagicMock
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
+from src.auth.dependencies import get_current_user
 from src.db.client import prisma
 from src.main import app
 
 
+def _make_mock_user(role: str = "CLINICIAN") -> MagicMock:
+    user = MagicMock()
+    user.id = "test-user-id"
+    user.externalId = "test-external-id"
+    user.email = "test@open-cis.local"
+    user.name = "Test User"
+    user.role = role
+    return user
+
+
 @pytest_asyncio.fixture
 async def client():
-    """Create an async test client."""
+    """Create an async test client with auth bypassed (CLINICIAN role)."""
+    mock_user = _make_mock_user("CLINICIAN")
+    app.dependency_overrides[get_current_user] = lambda: mock_user
     async with AsyncClient(
         transport=ASGITransport(app=app),
         base_url="http://test"
     ) as ac:
         yield ac
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+@pytest_asyncio.fixture
+async def admin_client():
+    """Create an async test client with ADMIN role."""
+    mock_user = _make_mock_user("ADMIN")
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test"
+    ) as ac:
+        yield ac
+    app.dependency_overrides.pop(get_current_user, None)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/api/tests/test_oehrpy_integration.py
+++ b/api/tests/test_oehrpy_integration.py
@@ -1,8 +1,8 @@
 """Tests for oehrpy SDK integration."""
 
 import pytest
-from openehr_sdk.client import EHRBaseClient as OehrpyClient
-from openehr_sdk.templates import VitalSignsBuilder
+from oehrpy.client import EHRBaseClient as OehrpyClient
+from oehrpy.templates import VitalSignsBuilder
 
 from src.ehrbase.client import EHRBaseClient
 from src.openehr.compositions import VITAL_SIGNS_TEMPLATE_ID, build_vital_signs_flat

--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -1,6 +1,6 @@
 FROM dexidp/dex:v2.39.1
 
-COPY config.railway.yaml /etc/dex/config.yaml
+COPY dex/config.railway.yaml /etc/dex/config.yaml
 
 EXPOSE 5556
 

--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/dex-idp/dex:v2.39.1
+FROM dexidp/dex:v2.39.1
 
 COPY config.railway.yaml /etc/dex/config.yaml
 

--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/dex-idp/dex:v2.39.1
+
+COPY config.railway.yaml /etc/dex/config.yaml
+
+EXPOSE 5556
+
+CMD ["dex", "serve", "/etc/dex/config.yaml"]

--- a/dex/README.md
+++ b/dex/README.md
@@ -8,6 +8,8 @@
 |---|---|
 | `config.yaml` | Local development config. Used by `docker-compose.yml`. Concrete values, no env substitution. |
 | `config.railway.yaml` | Railway/production config. Uses `${VAR}` placeholders populated from Railway environment variables. |
+| `Dockerfile` | Image built for Railway — extends the upstream Dex image and copies `config.railway.yaml` into it. |
+| `railway.toml` | Railway service config (Dockerfile path, healthcheck, restart policy). |
 
 ## Local Development
 
@@ -31,20 +33,9 @@ Dex runs on Railway as a separate service alongside `api`, `web`, and `app-db`. 
 In the Railway project:
 
 1. **New → Empty Service** (name it `dex`)
-2. **Settings → Source**: connect the same GitHub repo
-3. **Settings → Build**: select *Dockerfile* and set:
-   ```
-   Root Directory: dex
-   Dockerfile Path: Dockerfile
-   ```
-4. Create a minimal `dex/Dockerfile` in the repo (if not already present):
-   ```Dockerfile
-   FROM ghcr.io/dex-idp/dex:v2.39.1
-   COPY config.railway.yaml /etc/dex/config.yaml
-   EXPOSE 5556
-   CMD ["dex", "serve", "/etc/dex/config.yaml"]
-   ```
-5. **Settings → Networking → Public Networking**: generate a domain (e.g. `dex-open-cis.up.railway.app`)
+2. **Settings → Source**: connect the same GitHub repo, branch `main`
+3. The `dex/railway.toml` file already configures the Dockerfile path and healthcheck — no extra Railway settings are needed
+4. **Settings → Networking → Public Networking**: generate a domain (e.g. `dex-open-cis.up.railway.app`)
 
 ### 2. Set environment variables
 

--- a/dex/README.md
+++ b/dex/README.md
@@ -1,0 +1,148 @@
+# Dex OIDC Provider
+
+[Dex](https://dexidp.io/) is the OIDC provider for Open CIS authentication. It runs as a Docker Compose service locally and as a standalone Railway service for staging/demo deployments.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `config.yaml` | Local development config. Used by `docker-compose.yml`. Concrete values, no env substitution. |
+| `config.railway.yaml` | Railway/production config. Uses `${VAR}` placeholders populated from Railway environment variables. |
+
+## Local Development
+
+No extra steps — `docker compose up` mounts `config.yaml` into the Dex container.
+
+The default seeded users are:
+
+| Email | Password | Role (default) |
+|---|---|---|
+| `admin@open-cis.local` | `admin` | `CLINICIAN` (promote to `ADMIN` in DB) |
+| `clinician@open-cis.local` | `clinician` | `CLINICIAN` |
+
+Role elevation is done in the app database, not in Dex. See `api/prisma/schema.prisma`.
+
+## Railway Deployment
+
+Dex runs on Railway as a separate service alongside `api`, `web`, and `app-db`. This section covers adding and configuring that service.
+
+### 1. Create the Dex service
+
+In the Railway project:
+
+1. **New → Empty Service** (name it `dex`)
+2. **Settings → Source**: connect the same GitHub repo
+3. **Settings → Build**: select *Dockerfile* and set:
+   ```
+   Root Directory: dex
+   Dockerfile Path: Dockerfile
+   ```
+4. Create a minimal `dex/Dockerfile` in the repo (if not already present):
+   ```Dockerfile
+   FROM ghcr.io/dex-idp/dex:v2.39.1
+   COPY config.railway.yaml /etc/dex/config.yaml
+   EXPOSE 5556
+   CMD ["dex", "serve", "/etc/dex/config.yaml"]
+   ```
+5. **Settings → Networking → Public Networking**: generate a domain (e.g. `dex-open-cis.up.railway.app`)
+
+### 2. Set environment variables
+
+On the **dex** service, set:
+
+| Variable | Example value |
+|---|---|
+| `DEX_ISSUER` | `https://dex-open-cis.up.railway.app/dex` |
+| `DEX_REDIRECT_URI` | `https://open-cis-web.up.railway.app/auth/callback` |
+| `DEX_DEMO_ADMIN_HASH` | *(see below)* |
+| `DEX_DEMO_CLINICIAN_HASH` | *(see below)* |
+
+`DEX_ISSUER` **must** match the public URL of the Dex service exactly (including `/dex` path).
+
+`DEX_REDIRECT_URI` **must** match the public URL of the `web` service + `/auth/callback`.
+
+### 3. Generate bcrypt password hashes
+
+The demo passwords are hashed with bcrypt (cost 10). The default hashes in `.env.example` correspond to the passwords `admin` and `clinician`. **Replace them for any deployment you share a public URL for.**
+
+To generate new hashes:
+
+```bash
+# Python one-liner (requires bcrypt: pip install bcrypt)
+python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(10)).decode())"
+
+# Or with htpasswd
+htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
+```
+
+Copy each hash directly into the Railway env var panel. Hashes start with `$2b$10$…`. Escape any `$` signs if your deployment tool requires it (Railway's UI does not).
+
+### 4. Configure the `api` service
+
+On the **api** service, set:
+
+| Variable | Value |
+|---|---|
+| `OIDC_ISSUER` | Same as `DEX_ISSUER` above |
+| `OIDC_CLIENT_ID` | `open-cis-web` |
+
+### 5. Configure the `web` service
+
+On the **web** service, set:
+
+| Variable | Value |
+|---|---|
+| `VITE_OIDC_ISSUER` | Same as `DEX_ISSUER` above |
+| `VITE_OIDC_CLIENT_ID` | `open-cis-web` |
+| `VITE_APP_MODE` | `demo` *(optional — shows credential hints on login page)* |
+
+### 6. Verify
+
+After all services deploy, check:
+
+```bash
+curl https://dex-open-cis.up.railway.app/dex/.well-known/openid-configuration
+```
+
+You should see a valid OIDC discovery document with `authorization_endpoint`, `token_endpoint`, and `jwks_uri` all pointing at the Dex public URL.
+
+Then log into the web app — the Dex login page should appear, accept the demo credentials, and redirect back to the frontend authenticated.
+
+## Storage: Memory vs Postgres
+
+The Railway config uses `storage: type: memory`. This is intentional for demo deployments:
+
+- All sessions are lost on Dex restart (users re-authenticate)
+- No dynamic client registration is persisted
+- Zero extra infrastructure required
+
+For longer-lived staging or production, switch `config.railway.yaml` to Postgres storage and point at a Railway Postgres plugin:
+
+```yaml
+storage:
+  type: postgres
+  config:
+    host: ${DEX_DB_HOST}
+    port: 5432
+    database: ${DEX_DB_NAME}
+    user: ${DEX_DB_USER}
+    password: ${DEX_DB_PASSWORD}
+    ssl:
+      mode: require
+```
+
+## Notes on the Client Configuration
+
+The `open-cis-web` client is configured as a **public client** (`public: true`, no `secret`). This is correct for SPA clients that cannot safely hold a secret — security relies on PKCE + the registered redirect URI.
+
+Do not add a `secret:` field unless you also move the token exchange out of the browser and into the FastAPI backend.
+
+## Upgrading to Keycloak
+
+This prototype uses Dex. To swap to Keycloak (or any other OIDC provider) in production:
+
+1. Register a public client named `open-cis-web` with the same redirect URI
+2. Update `OIDC_ISSUER` / `VITE_OIDC_ISSUER` to the new realm URL
+3. No application code changes are required — validation goes through the OIDC discovery document
+
+See [ADR-0010](../docs/adr/0010-oidc-provider-choice.md) for the full rationale.

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -14,7 +14,7 @@ staticClients:
     redirectURIs:
       - ${DEX_REDIRECT_URI}
     name: Open CIS Web
-    secret: open-cis-secret
+    public: true
 
 enablePasswordDB: true
 

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -1,0 +1,30 @@
+issuer: ${DEX_ISSUER}
+
+storage:
+  type: memory
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: open-cis-web
+    redirectURIs:
+      - ${DEX_REDIRECT_URI}
+    name: Open CIS Web
+    secret: open-cis-secret
+
+enablePasswordDB: true
+
+staticPasswords:
+  - email: admin@open-cis.local
+    hash: "${DEX_DEMO_ADMIN_HASH}"
+    username: admin
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+  - email: clinician@open-cis.local
+    hash: "${DEX_DEMO_CLINICIAN_HASH}"
+    username: clinician
+    userID: "6c3f0ed7-6cf4-4d81-9e64-c30f8e5a0f22"

--- a/dex/config.yaml
+++ b/dex/config.yaml
@@ -22,7 +22,7 @@ staticClients:
     redirectURIs:
       - http://localhost:5173/auth/callback
     name: Open CIS Web
-    secret: open-cis-secret
+    public: true
 
 enablePasswordDB: true
 

--- a/dex/config.yaml
+++ b/dex/config.yaml
@@ -1,0 +1,38 @@
+issuer: http://localhost:5556/dex
+
+storage:
+  type: postgres
+  config:
+    host: app-db
+    port: 5432
+    database: cis
+    user: cis
+    password: cis
+    ssl:
+      mode: disable
+
+web:
+  http: 0.0.0.0:5556
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: open-cis-web
+    redirectURIs:
+      - http://localhost:5173/auth/callback
+    name: Open CIS Web
+    secret: open-cis-secret
+
+enablePasswordDB: true
+
+staticPasswords:
+  - email: admin@open-cis.local
+    hash: "$2b$10$0ZIL.9k.bCmO9SS.8hOFreuX32kXoTeAMQnUlPeX83aQwmB4/7VdC"
+    username: admin
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+
+  - email: clinician@open-cis.local
+    hash: "$2b$10$dnqTBcl8.TMjpfcb7gsZGujBC/HMLxuExPcK4MaVKUwonsK6b9CPm"
+    username: clinician
+    userID: "6c3f0ed7-6cf4-4d81-9e64-c30f8e5a0f22"

--- a/dex/railway.toml
+++ b/dex/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "dex/Dockerfile"
+watchPatterns = ["dex/Dockerfile", "dex/config.railway.yaml"]
+
+[deploy]
+healthcheckPath = "/dex/.well-known/openid-configuration"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,17 @@ services:
       timeout: 5s
       retries: 5
 
+  dex:
+    image: ghcr.io/dex-idp/dex:v2.39.1
+    ports:
+      - "5556:5556"
+    volumes:
+      - ./dex/config.yaml:/etc/dex/config.docker.yaml
+    command: ["dex", "serve", "/etc/dex/config.docker.yaml"]
+    depends_on:
+      app-db:
+        condition: service_healthy
+
 volumes:
   ehrbase-data:
   app-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,12 @@ services:
     depends_on:
       app-db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:5556/dex/.well-known/openid-configuration"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
 volumes:
   ehrbase-data:

--- a/docs/adr/0010-oidc-provider-choice.md
+++ b/docs/adr/0010-oidc-provider-choice.md
@@ -1,0 +1,51 @@
+# ADR-0010: OIDC Provider for Open CIS Authentication
+
+**Date:** 2026-04-06
+
+## Status
+
+Accepted
+
+## Context
+
+Open CIS needs an OAuth2/OIDC authorization server to serve two use cases:
+
+1. **CIS user authentication** — Clinicians, nurses, and admins log into the Open CIS frontend using an Authorization Code Flow with PKCE. The backend validates the resulting JWT to identify the user and enforce role-based access control.
+
+2. **SMART App Launch** (PRD-0006, future) — External SMART on FHIR apps launch into Open CIS and request scoped access to FHIR endpoints. The same OIDC provider issues SMART access tokens.
+
+### Options Evaluated
+
+- **Option A — Custom auth in FastAPI**: Rejected. Building auth logic from scratch is high-risk and cannot serve SMART App Launch.
+- **Option B — Keycloak**: Rejected for prototype. ~500 MB image with complex configuration. Right choice for production.
+- **Option C — Dex (CNCF)**: Small (~20 MB), standards-compliant OIDC provider. Single YAML config file. Can use existing `app-db` Postgres instance.
+
+## Decision
+
+We use **Dex** as the OIDC provider for local development and the prototype stage.
+
+The application is written against the standard OIDC interface — no Dex-specific code:
+
+- Backend reads `OIDC_ISSUER` from environment, fetches OIDC discovery, validates JWTs via JWKS.
+- Frontend uses Authorization Code Flow with PKCE, reading endpoints from OIDC discovery.
+
+Swapping to Keycloak requires only changing `OIDC_ISSUER`.
+
+### Role mapping
+
+Roles are managed in the Open CIS `User` table. On first login, the backend upserts a `User` record keyed on the OIDC `sub` claim, defaulting to `CLINICIAN`. Role elevation is done by an admin directly in the database.
+
+## Consequences
+
+**Positive:**
+- `docker compose up` produces a fully working auth stack.
+- Application code is OIDC-provider-agnostic from day one.
+- Dex's static password database gives all contributors identical seeded test users.
+- The same infrastructure serves SMART App Launch (PRD-0006).
+
+**Negative:**
+- Dex has no admin UI. Managing users beyond static accounts requires editing YAML config.
+- Dex's SMART scope support is generic OAuth2. The `/.well-known/smart-configuration` endpoint must be implemented in FastAPI.
+
+**Upgrade path:**
+Replace Dex with Keycloak by changing `OIDC_ISSUER` and registering redirect URIs.

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -40,6 +40,12 @@ export default [
         Response: 'readonly',
         localStorage: 'readonly',
         sessionStorage: 'readonly',
+        btoa: 'readonly',
+        atob: 'readonly',
+        crypto: 'readonly',
+        TextEncoder: 'readonly',
+        Uint8Array: 'readonly',
+        ArrayBuffer: 'readonly',
       },
     },
     plugins: {

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -1,15 +1,26 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
-import { RouterView } from 'vue-router'
-import { Github, Moon, Sun } from 'lucide-vue-next'
+import { ref, onMounted, computed } from 'vue'
+import { RouterView, useRoute, useRouter } from 'vue-router'
+import { Github, Moon, Sun, LogOut } from 'lucide-vue-next'
+import { useAuthStore } from '@/stores/auth'
 
 const version = __APP_VERSION__
 const isDark = ref(false)
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+
+const showNav = computed(() => !route.meta.public)
 
 function toggleDark() {
   isDark.value = !isDark.value
   document.documentElement.classList.toggle('dark', isDark.value)
   localStorage.setItem('theme', isDark.value ? 'dark' : 'light')
+}
+
+function handleLogout() {
+  auth.clearAuth()
+  router.push('/login')
 }
 
 onMounted(() => {
@@ -21,7 +32,7 @@ onMounted(() => {
 
 <template>
   <div class="min-h-screen bg-background">
-    <header class="border-b">
+    <header v-if="showNav" class="border-b">
       <div class="container flex h-16 items-center justify-between px-4">
         <nav class="flex items-center space-x-6">
           <RouterLink
@@ -60,6 +71,16 @@ onMounted(() => {
           </RouterLink>
         </nav>
         <div class="flex items-center gap-4">
+          <!-- User info + role badge -->
+          <div v-if="auth.user" class="flex items-center gap-2">
+            <span class="text-sm text-muted-foreground hidden sm:inline">
+              {{ auth.user.name }}
+            </span>
+            <span class="inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium text-muted-foreground">
+              {{ auth.user.role }}
+            </span>
+          </div>
+
           <button
             class="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:text-primary hover:bg-accent"
             :title="isDark ? 'Switch to light mode' : 'Switch to dark mode'"
@@ -79,10 +100,18 @@ onMounted(() => {
           <Github :size="18" />
           <span class="hidden sm:inline">Open Source</span>
         </a>
+        <button
+          v-if="auth.isAuthenticated"
+          class="inline-flex items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:text-destructive hover:bg-accent"
+          title="Sign out"
+          @click="handleLogout"
+        >
+          <LogOut :size="18" />
+        </button>
         </div>
       </div>
     </header>
-    <main class="container py-6">
+    <main :class="showNav ? 'container py-6' : ''">
       <RouterView />
     </main>
   </div>

--- a/web/src/components/auth/DemoCredentialRow.vue
+++ b/web/src/components/auth/DemoCredentialRow.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { useClipboard } from '@vueuse/core'
+
+const props = defineProps<{
+  label: string
+  email: string
+  password: string
+}>()
+
+const { copy: copyEmail, copied: emailCopied } = useClipboard()
+const { copy: copyPassword, copied: passwordCopied } = useClipboard()
+</script>
+
+<template>
+  <div class="flex items-center justify-between gap-2">
+    <span class="text-muted-foreground w-20 shrink-0">{{ label }}</span>
+    <code class="flex-1 text-xs truncate">{{ email }}</code>
+    <button
+      class="inline-flex items-center justify-center rounded text-xs px-2 py-1 hover:bg-accent text-muted-foreground shrink-0"
+      @click="copyEmail(props.email)"
+    >
+      {{ emailCopied ? 'Copied' : 'Copy' }}
+    </button>
+    <code class="w-20 text-xs shrink-0">{{ password }}</code>
+    <button
+      class="inline-flex items-center justify-center rounded text-xs px-2 py-1 hover:bg-accent text-muted-foreground shrink-0"
+      @click="copyPassword(props.password)"
+    >
+      {{ passwordCopied ? 'Copied' : 'Copy' }}
+    </button>
+  </div>
+</template>

--- a/web/src/components/auth/DemoCredentialRow.vue
+++ b/web/src/components/auth/DemoCredentialRow.vue
@@ -16,6 +16,8 @@ const { copy: copyPassword, copied: passwordCopied } = useClipboard()
     <span class="text-muted-foreground w-20 shrink-0">{{ label }}</span>
     <code class="flex-1 text-xs truncate">{{ email }}</code>
     <button
+      type="button"
+      :aria-label="`Copy ${label} email`"
       class="inline-flex items-center justify-center rounded text-xs px-2 py-1 hover:bg-accent text-muted-foreground shrink-0"
       @click="copyEmail(props.email)"
     >
@@ -23,6 +25,8 @@ const { copy: copyPassword, copied: passwordCopied } = useClipboard()
     </button>
     <code class="w-20 text-xs shrink-0">{{ password }}</code>
     <button
+      type="button"
+      :aria-label="`Copy ${label} password`"
       class="inline-flex items-center justify-center rounded text-xs px-2 py-1 hover:bg-accent text-muted-foreground shrink-0"
       @click="copyPassword(props.password)"
     >

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -26,6 +26,10 @@ interface RequestOptions extends RequestInit {
   params?: Record<string, string | number>
 }
 
+function getAuthToken(): string | null {
+  return localStorage.getItem('oidc_token')
+}
+
 async function request<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
   const { params, ...fetchOptions } = options
 
@@ -38,13 +42,30 @@ async function request<T>(endpoint: string, options: RequestOptions = {}): Promi
     url += `?${searchParams.toString()}`
   }
 
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(fetchOptions.headers as Record<string, string>),
+  }
+
+  const token = getAuthToken()
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+
   const response = await fetch(url, {
     ...fetchOptions,
-    headers: {
-      'Content-Type': 'application/json',
-      ...fetchOptions.headers,
-    },
+    headers,
   })
+
+  if (response.status === 401) {
+    // Clear auth state and redirect to login
+    localStorage.removeItem('oidc_token')
+    if (window.location.pathname !== '/login' && window.location.pathname !== '/auth/callback') {
+      window.location.href = '/login'
+    }
+    const fallback: ApiErrorBody = { error: 'internal_error', message: 'Unauthorized' }
+    throw new ApiRequestError(401, fallback)
+  }
 
   if (!response.ok) {
     const fallback: ApiErrorBody = {

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -5,13 +5,19 @@
 export const OIDC_ISSUER = import.meta.env.VITE_OIDC_ISSUER || 'http://localhost:5556/dex'
 export const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID || 'open-cis-web'
 export const OIDC_REDIRECT_URI = `${window.location.origin}/auth/callback`
-export const OIDC_CLIENT_SECRET = 'open-cis-secret'
 
 interface OidcDiscovery {
   authorization_endpoint: string
   token_endpoint: string
   userinfo_endpoint: string
   jwks_uri: string
+}
+
+interface TokenResponse {
+  access_token: string
+  id_token?: string
+  token_type: string
+  expires_in?: number
 }
 
 let cachedDiscovery: OidcDiscovery | null = null
@@ -23,11 +29,20 @@ export async function getOidcDiscovery(): Promise<OidcDiscovery> {
   if (!response.ok) {
     throw new Error(`Failed to fetch OIDC discovery: ${response.status}`)
   }
-  cachedDiscovery = await response.json()
-  return cachedDiscovery!
+  cachedDiscovery = await response.json() as OidcDiscovery
+  return cachedDiscovery
 }
 
-export async function exchangeCodeForToken(code: string, codeVerifier: string): Promise<string> {
+export function generateState(): string {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return Array.from(array, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+export async function exchangeCodeForToken(
+  code: string,
+  codeVerifier: string,
+): Promise<string> {
   const discovery = await getOidcDiscovery()
 
   const body = new URLSearchParams({
@@ -35,7 +50,6 @@ export async function exchangeCodeForToken(code: string, codeVerifier: string): 
     code,
     redirect_uri: OIDC_REDIRECT_URI,
     client_id: OIDC_CLIENT_ID,
-    client_secret: OIDC_CLIENT_SECRET,
     code_verifier: codeVerifier,
   })
 
@@ -50,6 +64,9 @@ export async function exchangeCodeForToken(code: string, codeVerifier: string): 
     throw new Error(`Token exchange failed: ${response.status} ${text}`)
   }
 
-  const data = await response.json()
-  return data.id_token || data.access_token
+  const data = (await response.json()) as TokenResponse
+  if (!data.access_token) {
+    throw new Error('Token response missing access_token')
+  }
+  return data.access_token
 }

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -1,0 +1,55 @@
+/**
+ * OIDC configuration derived from environment variables.
+ */
+
+export const OIDC_ISSUER = import.meta.env.VITE_OIDC_ISSUER || 'http://localhost:5556/dex'
+export const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID || 'open-cis-web'
+export const OIDC_REDIRECT_URI = `${window.location.origin}/auth/callback`
+export const OIDC_CLIENT_SECRET = 'open-cis-secret'
+
+interface OidcDiscovery {
+  authorization_endpoint: string
+  token_endpoint: string
+  userinfo_endpoint: string
+  jwks_uri: string
+}
+
+let cachedDiscovery: OidcDiscovery | null = null
+
+export async function getOidcDiscovery(): Promise<OidcDiscovery> {
+  if (cachedDiscovery) return cachedDiscovery
+
+  const response = await fetch(`${OIDC_ISSUER}/.well-known/openid-configuration`)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch OIDC discovery: ${response.status}`)
+  }
+  cachedDiscovery = await response.json()
+  return cachedDiscovery!
+}
+
+export async function exchangeCodeForToken(code: string, codeVerifier: string): Promise<string> {
+  const discovery = await getOidcDiscovery()
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: OIDC_REDIRECT_URI,
+    client_id: OIDC_CLIENT_ID,
+    client_secret: OIDC_CLIENT_SECRET,
+    code_verifier: codeVerifier,
+  })
+
+  const response = await fetch(discovery.token_endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Token exchange failed: ${response.status} ${text}`)
+  }
+
+  const data = await response.json()
+  return data.id_token || data.access_token
+}

--- a/web/src/lib/pkce.ts
+++ b/web/src/lib/pkce.ts
@@ -1,0 +1,25 @@
+/**
+ * PKCE (Proof Key for Code Exchange) utilities for OAuth2 Authorization Code Flow.
+ */
+
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let str = ''
+  for (const byte of bytes) {
+    str += String.fromCharCode(byte)
+  }
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function generateCodeVerifier(): string {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return base64UrlEncode(array.buffer)
+}
+
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder()
+  const data = encoder.encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(digest)
+}

--- a/web/src/pages/auth/AuthCallbackPage.vue
+++ b/web/src/pages/auth/AuthCallbackPage.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { Loader2 } from 'lucide-vue-next'
+import { exchangeCodeForToken } from '@/lib/oidc'
+import { useAuthStore } from '@/stores/auth'
+
+const router = useRouter()
+const route = useRoute()
+const auth = useAuthStore()
+
+const error = ref<string | null>(null)
+
+onMounted(async () => {
+  const code = route.query.code as string | undefined
+  const codeVerifier = sessionStorage.getItem('oidc_code_verifier')
+
+  if (!code) {
+    error.value = 'No authorization code received. Please try logging in again.'
+    return
+  }
+
+  if (!codeVerifier) {
+    error.value = 'Login session expired. Please try again.'
+    return
+  }
+
+  try {
+    const token = await exchangeCodeForToken(code, codeVerifier)
+    sessionStorage.removeItem('oidc_code_verifier')
+    auth.setToken(token)
+
+    const success = await auth.fetchMe()
+    if (success) {
+      router.replace('/')
+    } else {
+      error.value = 'Failed to load user profile. Please try again.'
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Authentication failed'
+  }
+})
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-background px-4">
+    <div class="text-center space-y-4">
+      <div v-if="!error">
+        <Loader2 class="h-8 w-8 animate-spin mx-auto mb-4 text-muted-foreground" />
+        <p class="text-sm text-muted-foreground">Completing sign in...</p>
+      </div>
+
+      <div v-else class="max-w-sm space-y-4">
+        <div class="rounded-md border border-destructive/50 bg-destructive/10 p-4 text-sm text-destructive">
+          {{ error }}
+        </div>
+        <RouterLink
+          to="/login"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground h-10 px-4 py-2 hover:bg-primary/90"
+        >
+          Back to Login
+        </RouterLink>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/pages/auth/AuthCallbackPage.vue
+++ b/web/src/pages/auth/AuthCallbackPage.vue
@@ -11,23 +11,39 @@ const auth = useAuthStore()
 
 const error = ref<string | null>(null)
 
+function cleanupSession() {
+  sessionStorage.removeItem('oidc_code_verifier')
+  sessionStorage.removeItem('oidc_state')
+}
+
 onMounted(async () => {
   const code = route.query.code as string | undefined
+  const returnedState = route.query.state as string | undefined
   const codeVerifier = sessionStorage.getItem('oidc_code_verifier')
+  const savedState = sessionStorage.getItem('oidc_state')
 
   if (!code) {
+    cleanupSession()
     error.value = 'No authorization code received. Please try logging in again.'
     return
   }
 
   if (!codeVerifier) {
+    cleanupSession()
     error.value = 'Login session expired. Please try again.'
+    return
+  }
+
+  // CSRF protection: validate state parameter
+  if (!savedState || savedState !== returnedState) {
+    cleanupSession()
+    error.value = 'Invalid state parameter. Possible CSRF attack. Please try again.'
     return
   }
 
   try {
     const token = await exchangeCodeForToken(code, codeVerifier)
-    sessionStorage.removeItem('oidc_code_verifier')
+    cleanupSession()
     auth.setToken(token)
 
     const success = await auth.fetchMe()
@@ -37,6 +53,7 @@ onMounted(async () => {
       error.value = 'Failed to load user profile. Please try again.'
     }
   } catch (e) {
+    cleanupSession()
     error.value = e instanceof Error ? e.message : 'Authentication failed'
   }
 })

--- a/web/src/pages/auth/LoginPage.vue
+++ b/web/src/pages/auth/LoginPage.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Loader2, LogIn } from 'lucide-vue-next'
+import { generateCodeVerifier, generateCodeChallenge } from '@/lib/pkce'
+import { getOidcDiscovery, OIDC_CLIENT_ID, OIDC_REDIRECT_URI } from '@/lib/oidc'
+import DemoCredentialRow from '@/components/auth/DemoCredentialRow.vue'
+
+const isDemoMode = import.meta.env.VITE_APP_MODE === 'demo'
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+async function startLogin() {
+  loading.value = true
+  error.value = null
+  try {
+    const discovery = await getOidcDiscovery()
+    const codeVerifier = generateCodeVerifier()
+    const codeChallenge = await generateCodeChallenge(codeVerifier)
+
+    // Store verifier for the callback
+    sessionStorage.setItem('oidc_code_verifier', codeVerifier)
+
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: OIDC_CLIENT_ID,
+      redirect_uri: OIDC_REDIRECT_URI,
+      scope: 'openid email profile',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    })
+
+    window.location.href = `${discovery.authorization_endpoint}?${params.toString()}`
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to start login'
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-background px-4">
+    <div class="w-full max-w-sm space-y-6">
+      <!-- Logo & Title -->
+      <div class="text-center space-y-2">
+        <div class="flex justify-center">
+          <svg width="48" height="48" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M20 65L50 80L80 65V50L50 65L20 50V65Z" fill="#F39200"/>
+            <path d="M50 35L80 50L50 65L20 50L50 35Z" fill="#F39200" fill-opacity="0.8"/>
+            <path d="M20 40L50 55L80 40V25L50 40L20 25V40Z" fill="currentColor" class="text-[#005EB8] dark:text-white"/>
+            <path d="M50 10L80 25L50 40L20 25L50 10Z" fill="currentColor" fill-opacity="0.8" class="text-[#005EB8] dark:text-white"/>
+          </svg>
+        </div>
+        <h1 class="text-2xl tracking-tighter">
+          <span class="font-light">open</span><span class="font-black text-primary">cis</span>
+        </h1>
+        <p class="text-sm text-muted-foreground">
+          Sign in to access the Clinical Information System
+        </p>
+      </div>
+
+      <!-- Error -->
+      <div
+        v-if="error"
+        class="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+      >
+        {{ error }}
+      </div>
+
+      <!-- Sign In Button -->
+      <button
+        class="inline-flex w-full items-center justify-center rounded-md text-sm font-medium bg-primary text-primary-foreground h-11 px-4 py-2 hover:bg-primary/90 disabled:opacity-50 disabled:pointer-events-none"
+        :disabled="loading"
+        @click="startLogin"
+      >
+        <Loader2 v-if="loading" class="h-4 w-4 mr-2 animate-spin" />
+        <LogIn v-else class="h-4 w-4 mr-2" />
+        Sign in with OIDC
+      </button>
+
+      <!-- Demo Credentials -->
+      <div
+        v-if="isDemoMode"
+        class="rounded-lg border border-dashed p-4 text-sm"
+      >
+        <p class="font-medium text-muted-foreground mb-3">Demo accounts</p>
+        <div class="space-y-2">
+          <DemoCredentialRow
+            label="Clinician"
+            email="clinician@open-cis.local"
+            password="clinician"
+          />
+          <DemoCredentialRow
+            label="Admin"
+            email="admin@open-cis.local"
+            password="admin"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/pages/auth/LoginPage.vue
+++ b/web/src/pages/auth/LoginPage.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { Loader2, LogIn } from 'lucide-vue-next'
 import { generateCodeVerifier, generateCodeChallenge } from '@/lib/pkce'
-import { getOidcDiscovery, OIDC_CLIENT_ID, OIDC_REDIRECT_URI } from '@/lib/oidc'
+import { getOidcDiscovery, generateState, OIDC_CLIENT_ID, OIDC_REDIRECT_URI } from '@/lib/oidc'
 import DemoCredentialRow from '@/components/auth/DemoCredentialRow.vue'
 
 const isDemoMode = import.meta.env.VITE_APP_MODE === 'demo'
@@ -16,9 +16,11 @@ async function startLogin() {
     const discovery = await getOidcDiscovery()
     const codeVerifier = generateCodeVerifier()
     const codeChallenge = await generateCodeChallenge(codeVerifier)
+    const state = generateState()
 
-    // Store verifier for the callback
+    // Store verifier and state for the callback
     sessionStorage.setItem('oidc_code_verifier', codeVerifier)
+    sessionStorage.setItem('oidc_state', state)
 
     const params = new URLSearchParams({
       response_type: 'code',
@@ -27,6 +29,7 @@ async function startLogin() {
       scope: 'openid email profile',
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
+      state,
     })
 
     window.location.href = `${discovery.authorization_endpoint}?${params.toString()}`

--- a/web/src/pages/patients/PatientDetailPage.vue
+++ b/web/src/pages/patients/PatientDetailPage.vue
@@ -6,6 +6,7 @@ import { X, Loader2, Pencil, Trash2, AlertTriangle } from 'lucide-vue-next'
 import { usePatientStore } from '@/stores/patient'
 import { useEncounterStore } from '@/stores/encounter'
 import { useCaveStore } from '@/stores/cave'
+import { useAuthStore } from '@/stores/auth'
 import type { PatientUpdate } from '@/types'
 import VitalSignsPanel from '@/components/vitals/VitalSignsPanel.vue'
 import CaveBanner from '@/components/cave/CaveBanner.vue'
@@ -16,6 +17,7 @@ const router = useRouter()
 const store = usePatientStore()
 const encounterStore = useEncounterStore()
 const caveStore = useCaveStore()
+const authStore = useAuthStore()
 
 const patientId = route.params.id as string
 
@@ -468,8 +470,8 @@ const openDeleteDialog = () => {
         </div>
       </div>
 
-      <!-- Danger Zone -->
-      <div class="rounded-lg border border-destructive/50 p-6">
+      <!-- Danger Zone (admin only) -->
+      <div v-if="authStore.isAdmin" class="rounded-lg border border-destructive/50 p-6">
         <div class="flex items-start gap-4">
           <AlertTriangle class="h-5 w-5 text-destructive mt-0.5" />
           <div class="flex-1">

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -1,8 +1,21 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 
 const router = createRouter({
   history: createWebHistory(),
   routes: [
+    {
+      path: '/login',
+      name: 'login',
+      component: () => import('@/pages/auth/LoginPage.vue'),
+      meta: { public: true },
+    },
+    {
+      path: '/auth/callback',
+      name: 'auth-callback',
+      component: () => import('@/pages/auth/AuthCallbackPage.vue'),
+      meta: { public: true },
+    },
     {
       path: '/',
       name: 'dashboard',
@@ -34,6 +47,24 @@ const router = createRouter({
       component: () => import('@/pages/SystemInfoPage.vue'),
     },
   ],
+})
+
+router.beforeEach(async (to) => {
+  const auth = useAuthStore()
+
+  // Allow public routes
+  if (to.meta.public) return true
+
+  // Redirect to login if not authenticated
+  if (!auth.isAuthenticated) return '/login'
+
+  // Fetch user profile if token exists but user not loaded
+  if (!auth.user) {
+    const success = await auth.fetchMe()
+    if (!success) return '/login'
+  }
+
+  return true
 })
 
 export default router

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -60,8 +60,13 @@ router.beforeEach(async (to) => {
 
   // Fetch user profile if token exists but user not loaded
   if (!auth.user) {
-    const success = await auth.fetchMe()
-    if (!success) return '/login'
+    try {
+      const success = await auth.fetchMe()
+      if (!success) return '/login'
+    } catch {
+      // Network/server error — allow navigation, user can retry
+      return true
+    }
   }
 
   return true

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,38 +1,45 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
+import { api } from '@/lib/api'
 
-interface User {
+export interface CurrentUser {
   id: string
   email: string
   name: string
-  role: string
+  role: 'ADMIN' | 'CLINICIAN' | 'NURSE' | 'READONLY'
 }
 
 export const useAuthStore = defineStore('auth', () => {
-  const user = ref<User | null>(null)
-  const token = ref<string | null>(null)
+  const token = ref<string | null>(localStorage.getItem('oidc_token'))
+  const user = ref<CurrentUser | null>(null)
 
-  const isAuthenticated = computed(() => !!user.value)
+  const isAuthenticated = computed(() => !!token.value)
+  const isAdmin = computed(() => user.value?.role === 'ADMIN')
+  const canWrite = computed(() =>
+    !!user.value && ['ADMIN', 'CLINICIAN', 'NURSE'].includes(user.value.role),
+  )
 
-  function setUser(userData: User) {
-    user.value = userData
+  function setToken(newToken: string) {
+    token.value = newToken
+    localStorage.setItem('oidc_token', newToken)
   }
 
-  function setToken(tokenValue: string) {
-    token.value = tokenValue
-  }
-
-  function logout() {
-    user.value = null
+  function clearAuth() {
     token.value = null
+    user.value = null
+    localStorage.removeItem('oidc_token')
   }
 
-  return {
-    user,
-    token,
-    isAuthenticated,
-    setUser,
-    setToken,
-    logout,
+  async function fetchMe(): Promise<boolean> {
+    try {
+      const data = await api.get<CurrentUser>('/api/auth/me')
+      user.value = data
+      return true
+    } catch {
+      clearAuth()
+      return false
+    }
   }
+
+  return { token, user, isAuthenticated, isAdmin, canWrite, setToken, clearAuth, fetchMe }
 })

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { api } from '@/lib/api'
+import { api, ApiRequestError } from '@/lib/api'
 
 export interface CurrentUser {
   id: string
@@ -30,14 +30,23 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.removeItem('oidc_token')
   }
 
+  /**
+   * Fetch the current user profile.
+   * Returns true on success, false on auth failure (401/403).
+   * Throws on network/server errors to allow retry.
+   */
   async function fetchMe(): Promise<boolean> {
     try {
       const data = await api.get<CurrentUser>('/api/auth/me')
       user.value = data
       return true
-    } catch {
-      clearAuth()
-      return false
+    } catch (e) {
+      if (e instanceof ApiRequestError && (e.status === 401 || e.status === 403)) {
+        clearAuth()
+        return false
+      }
+      // Network or server error — don't clear auth, propagate for retry
+      throw e
     }
   }
 

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -4,6 +4,9 @@ declare const __APP_VERSION__: string
 
 interface ImportMetaEnv {
   readonly VITE_API_URL?: string
+  readonly VITE_OIDC_ISSUER?: string
+  readonly VITE_OIDC_CLIENT_ID?: string
+  readonly VITE_APP_MODE?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Implements a complete OAuth2/OIDC authentication system using Dex as the identity provider, with JWT validation on the backend and role-based access control (RBAC) across all API endpoints.

## Key Changes

**Frontend Authentication:**
- New login page (`LoginPage.vue`) with OIDC Authorization Code Flow + PKCE
- Auth callback handler (`AuthCallbackPage.vue`) to exchange authorization code for JWT
- PKCE utilities for secure code exchange
- OIDC discovery and token exchange functions
- Demo credentials display in demo mode
- Updated auth store with token persistence and user profile fetching
- Protected routes with automatic redirect to login for unauthenticated users
- User info and role badge in navigation header with logout button

**Backend Authentication & Authorization:**
- JWT validation dependency (`get_current_user`) that validates Bearer tokens against OIDC provider's JWKS
- User upsert on first login, keyed on OIDC `sub` claim with default `CLINICIAN` role
- Role-based access control dependency (`require_role`) for endpoint protection
- Auth router with `/api/auth/me` endpoint to fetch current user profile
- Audit logging service to track mutations (CREATE, UPDATE, DELETE) with user context

**API Endpoint Protection:**
- All patient, encounter, CAVE, and observation endpoints now require authentication
- Write operations (POST, PATCH, DELETE) require specific roles (ADMIN, CLINICIAN, NURSE)
- Read operations require authentication but no specific role
- Audit logs created for all mutations with user ID, action, resource, and metadata

**Infrastructure:**
- Dex OIDC provider service in docker-compose with Postgres storage
- Static password database with seeded demo accounts (admin/clinician)
- Dex configuration for local development and Railway deployment
- Database migration to add `externalId` field to User model for OIDC `sub` claim mapping

**Configuration:**
- Environment variables for OIDC issuer, client ID, and demo mode
- Updated API client to include Bearer token in Authorization header
- 401 response handling with automatic logout and redirect to login

## Implementation Details

- Uses standard OIDC discovery to fetch endpoints dynamically—no Dex-specific code
- JWT validation uses JWKS caching to minimize external calls
- Role elevation managed directly in database (no OIDC group mapping)
- Session storage for PKCE code verifier during auth flow
- localStorage for persistent JWT token across page reloads
- Audit logs capture user actions for compliance and debugging
- ADR-0010 documents the choice of Dex over Keycloak for prototype stage with upgrade path documented

https://claude.ai/code/session_011DpANarsbKGhxkUD7MkUMX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC sign-in (Authorization Code + PKCE), login callback flow, token exchange, /me auth endpoint, and demo Dex sign‑in UI/credentials.

* **Changes**
  * App-wide auth gating and role-based access control; auth token persisted in browser; route guards; audit logging for create/update/delete; users linked to external OIDC IDs.

* **Documentation**
  * ADR added documenting OIDC provider choice.

* **Tests**
  * Fixtures for mocked authenticated and admin test clients.

* **Chores**
  * Demo env vars and Dex service/configuration added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->