### PR TITLE
feat: Add FHIR terminology server integration (PRD-0012)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ EHRBASE_PASSWORD=
 # CORS origins - for API service (JSON array)
 CORS_ORIGINS=["http://localhost:5173"]
 
+# FHIR Terminology Server - for API service (PRD-0012)
+TERMINOLOGY_SERVER_URL=https://tx.fhir.ch/r4
+TERMINOLOGY_ENABLED=true
+TERMINOLOGY_CACHE_TTL_SECONDS=3600
+TERMINOLOGY_TIMEOUT_SECONDS=5
+
 # Frontend - for web service
 VITE_API_URL=http://localhost:8000
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "aiofiles>=23.2.0",
     "faker>=22.0.0",
     "oehrpy>=0.7.0",
+    "cachetools>=5.3.0",
 ]
 
 [project.optional-dependencies]
@@ -24,6 +25,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.8.0",
     "types-aiofiles>=23.2.0",
+    "types-cachetools>=5.3.0",
 ]
 
 [build-system]

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -19,6 +19,12 @@ class Settings(BaseSettings):
     ehrbase_timeout: float = 30.0
     ehrbase_verify_ssl: bool = True
 
+    # FHIR Terminology Server (PRD-0012)
+    terminology_server_url: str = "https://tx.fhir.ch/r4"
+    terminology_enabled: bool = True
+    terminology_cache_ttl_seconds: int = 3600
+    terminology_timeout_seconds: float = 5.0
+
     class Config:
         env_file = ".env"
         extra = "ignore"  # Ignore extra env vars not in Settings

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -21,6 +21,9 @@ from src.errors import (
 from src.observations.router import router as observations_router
 from src.patients.router import router as patients_router
 from src.system.router import router as system_router
+from src.terminology.client import terminology_client
+from src.terminology.router import fhir_router as fhir_terminology_router
+from src.terminology.router import router as terminology_router
 
 # Configure logging
 logging.basicConfig(
@@ -62,6 +65,7 @@ async def lifespan(app: FastAPI):
     if prisma.is_connected():
         await prisma.disconnect()
     await ehrbase_client.close()
+    await terminology_client.close()
 
 
 try:
@@ -89,6 +93,8 @@ app.include_router(encounters_router, prefix="/api/encounters", tags=["encounter
 app.include_router(observations_router, prefix="/api/observations", tags=["observations"])
 app.include_router(cave_router, prefix="/api/cave", tags=["cave"])
 app.include_router(system_router, prefix="/api/system", tags=["system"])
+app.include_router(terminology_router, prefix="/api/terminology", tags=["terminology"])
+app.include_router(fhir_terminology_router, prefix="/api/fhir", tags=["fhir-terminology"])
 
 
 @app.exception_handler(EHRBaseValidationError)

--- a/api/src/observations/router.py
+++ b/api/src/observations/router.py
@@ -1,10 +1,12 @@
 """Router for vital signs observations with openEHR transparency."""
 
+import logging
 from datetime import datetime
 from typing import Literal
 
 from fastapi import APIRouter, HTTPException, Query
 
+from src.config import settings
 from src.ehrbase.client import ehrbase_client
 from src.observations.schemas import (
     RawCompositionResponse,
@@ -15,6 +17,10 @@ from src.observations.schemas import (
     VitalSignsResponse,
 )
 from src.observations.service import observation_service
+from src.terminology.client import terminology_client
+from src.terminology.enrichment import enrich_flat_composition
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -148,16 +154,28 @@ async def get_raw_composition(
     composition_uid: str,
     patient_id: str = Query(..., description="Patient ID for EHR lookup"),
     format: Literal["FLAT", "STRUCTURED"] = Query("FLAT", description="Composition format"),
+    enrich: bool = Query(True, description="Enrich coded terms with display names"),
 ) -> RawCompositionResponse:
     """Get raw composition data for transparency.
 
     Returns the full composition in the requested format (FLAT or STRUCTURED).
+    When enrich=True (default), DV_CODED_TEXT values are resolved to display terms
+    via the configured FHIR terminology server.
     """
     result = await observation_service.get_raw_composition(
         composition_uid, patient_id, format
     )
     if not result:
         raise HTTPException(status_code=404, detail="Composition not found")
+
+    if enrich and settings.terminology_enabled and format == "FLAT":
+        try:
+            result["composition"] = await enrich_flat_composition(
+                result["composition"], terminology_client
+            )
+        except Exception as e:
+            logger.warning("Composition enrichment failed (non-blocking): %s", e)
+
     return RawCompositionResponse(**result)
 
 

--- a/api/src/system/schemas.py
+++ b/api/src/system/schemas.py
@@ -27,6 +27,7 @@ class HealthChecksData(BaseModel):
     api: HealthCheckItem
     database: HealthCheckItem
     ehrbase: HealthCheckItem
+    terminology: HealthCheckItem
 
 
 class TemplateInfo(BaseModel):
@@ -73,8 +74,20 @@ class DbCountsSection(BaseModel):
     error: SectionError | None = None
 
 
+class TerminologyData(BaseModel):
+    url: str = Field(..., description="Configured terminology server URL")
+    response_ms: int | None = Field(None, description="Response time in milliseconds")
+
+
+class TerminologySection(BaseModel):
+    status: str
+    data: TerminologyData | None = None
+    error: SectionError | None = None
+
+
 class SystemInfoResponse(BaseModel):
     healthChecks: HealthChecksSection
     version: VersionSection
     templates: TemplatesSection
     dbCounts: DbCountsSection
+    terminology: TerminologySection

--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import logging
 from typing import Any
 
+from src.config import settings
 from src.db.client import prisma
 from src.ehrbase.client import ehrbase_client
 from src.ehrbase.templates import get_web_template_cache_status
@@ -16,9 +17,12 @@ from src.system.schemas import (
     SystemInfoResponse,
     TemplateInfo,
     TemplatesSection,
+    TerminologyData,
+    TerminologySection,
     VersionData,
     VersionSection,
 )
+from src.terminology.client import terminology_client
 
 logger = logging.getLogger(__name__)
 
@@ -26,21 +30,25 @@ logger = logging.getLogger(__name__)
 class SystemService:
     async def get_system_info(self) -> SystemInfoResponse:
         """Aggregate system health, versions, templates, and data stats."""
-        ehrbase_result, stats_result = await asyncio.gather(
+        ehrbase_result, stats_result, terminology_result = await asyncio.gather(
             self._get_ehrbase_info(),
             self._get_data_stats(),
+            self._get_terminology_info(),
             return_exceptions=True,
         )
 
         return SystemInfoResponse(
-            healthChecks=self._build_health_checks(ehrbase_result),
+            healthChecks=self._build_health_checks(ehrbase_result, terminology_result),
             version=self._build_version(ehrbase_result),
             templates=self._build_templates(ehrbase_result),
             dbCounts=self._build_db_counts(stats_result),
+            terminology=self._build_terminology(terminology_result),
         )
 
     def _build_health_checks(
-        self, ehrbase_result: dict[str, Any] | BaseException
+        self,
+        ehrbase_result: dict[str, Any] | BaseException,
+        terminology_result: dict[str, Any] | BaseException | None = None,
     ) -> HealthChecksSection:
         db_connected = prisma.is_connected()
 
@@ -86,7 +94,42 @@ class SystemService:
                     ),
                 )
 
-        items = [api_item, db_item, ehrbase_item]
+        # Terminology health check
+        if isinstance(terminology_result, BaseException) or terminology_result is None:
+            terminology_item = HealthCheckItem(
+                status="error",
+                data=None,
+                error=SectionError(
+                    code="TERMINOLOGY_UNAVAILABLE",
+                    message="Cannot connect to terminology server",
+                ),
+            )
+        else:
+            term_status = terminology_result.get("status", "offline")
+            if term_status == "online":
+                terminology_item = HealthCheckItem(
+                    status="ok", data={"status": "online"}, error=None
+                )
+            elif term_status == "degraded":
+                terminology_item = HealthCheckItem(
+                    status="ok",
+                    data={"status": "degraded"},
+                    error=SectionError(
+                        code="TERMINOLOGY_SLOW",
+                        message="Terminology server is slow (>2s)",
+                    ),
+                )
+            else:
+                terminology_item = HealthCheckItem(
+                    status="error",
+                    data=None,
+                    error=SectionError(
+                        code="TERMINOLOGY_UNAVAILABLE",
+                        message="Terminology server is not responding",
+                    ),
+                )
+
+        items = [api_item, db_item, ehrbase_item, terminology_item]
         error_count = sum(1 for i in items if i.status == "error")
 
         if error_count == 0:
@@ -105,7 +148,12 @@ class SystemService:
 
         return HealthChecksSection(
             status=section_status,
-            data=HealthChecksData(api=api_item, database=db_item, ehrbase=ehrbase_item),
+            data=HealthChecksData(
+                api=api_item,
+                database=db_item,
+                ehrbase=ehrbase_item,
+                terminology=terminology_item,
+            ),
             error=section_error,
         )
 
@@ -212,6 +260,58 @@ class SystemService:
             logger.debug("Could not fetch templates: %s", e)
 
         return result
+
+    def _build_terminology(
+        self, terminology_result: dict[str, Any] | BaseException
+    ) -> TerminologySection:
+        if isinstance(terminology_result, BaseException):
+            logger.warning("Terminology info fetch failed: %s", terminology_result)
+            return TerminologySection(
+                status="error",
+                data=TerminologyData(
+                    url=settings.terminology_server_url, response_ms=None
+                ),
+                error=SectionError(
+                    code="TERMINOLOGY_UNAVAILABLE",
+                    message="Cannot connect to terminology server",
+                ),
+            )
+
+        status = terminology_result.get("status", "offline")
+        response_ms = terminology_result.get("response_ms")
+
+        data = TerminologyData(
+            url=settings.terminology_server_url, response_ms=response_ms
+        )
+
+        if status == "online":
+            return TerminologySection(status="ok", data=data, error=None)
+        elif status == "degraded":
+            return TerminologySection(
+                status="partial",
+                data=data,
+                error=SectionError(
+                    code="TERMINOLOGY_SLOW",
+                    message="Terminology server is slow (>2s response time)",
+                ),
+            )
+        else:
+            return TerminologySection(
+                status="error",
+                data=data,
+                error=SectionError(
+                    code="TERMINOLOGY_UNAVAILABLE",
+                    message="Terminology server is not responding",
+                ),
+            )
+
+    async def _get_terminology_info(self) -> dict[str, Any]:
+        """Check terminology server health."""
+        if not settings.terminology_enabled:
+            return {"status": "offline", "response_ms": None}
+
+        status, response_ms = await terminology_client.health_check()
+        return {"status": status, "response_ms": response_ms}
 
     async def _get_data_stats(self) -> DbCountsData:
         """Fetch counts from the application database."""

--- a/api/src/terminology/client.py
+++ b/api/src/terminology/client.py
@@ -1,0 +1,181 @@
+"""Async FHIR R4 terminology client backed by httpx with in-memory TTL cache."""
+
+import logging
+import time
+
+import httpx
+from cachetools import TTLCache
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class TerminologyClient:
+    """Async FHIR R4 terminology client.
+
+    Backed by httpx.AsyncClient and cachetools TTLCache.
+    All operations fail softly — returning None/False on errors
+    so that a terminology server outage never blocks composition reads.
+    """
+
+    def __init__(self) -> None:
+        self._client: httpx.AsyncClient | None = None
+        self._lookup_cache: TTLCache = TTLCache(
+            maxsize=10_000, ttl=settings.terminology_cache_ttl_seconds
+        )
+        self._validate_cache: TTLCache = TTLCache(
+            maxsize=5_000, ttl=settings.terminology_cache_ttl_seconds
+        )
+
+    def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=settings.terminology_server_url,
+                timeout=settings.terminology_timeout_seconds,
+                headers={"Accept": "application/fhir+json"},
+            )
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def lookup(self, system: str, code: str) -> str | None:
+        """Return display term for a code, or None if not found.
+
+        Uses CodeSystem/$lookup FHIR operation.
+        Results are cached in-memory with TTL.
+        """
+        if not settings.terminology_enabled:
+            return None
+
+        cache_key = (system, code)
+        if cache_key in self._lookup_cache:
+            return self._lookup_cache[cache_key]
+
+        try:
+            client = self._ensure_client()
+            response = await client.get(
+                "/CodeSystem/$lookup",
+                params={"system": system, "code": code},
+            )
+            if response.status_code != 200:
+                logger.debug(
+                    "Terminology lookup failed: %s %s → HTTP %d",
+                    system, code, response.status_code,
+                )
+                self._lookup_cache[cache_key] = None
+                return None
+
+            data = response.json()
+            display = self._extract_display_from_parameters(data)
+            self._lookup_cache[cache_key] = display
+            return display
+        except Exception as e:
+            logger.debug("Terminology lookup error for %s|%s: %s", system, code, e)
+            return None
+
+    async def validate_code(
+        self, value_set_url: str, system: str, code: str
+    ) -> bool:
+        """Return True if code is a member of the given ValueSet.
+
+        Uses ValueSet/$validate-code FHIR operation.
+        """
+        if not settings.terminology_enabled:
+            return True  # permissive when disabled
+
+        cache_key = (value_set_url, system, code)
+        if cache_key in self._validate_cache:
+            return self._validate_cache[cache_key]
+
+        try:
+            client = self._ensure_client()
+            response = await client.get(
+                "/ValueSet/$validate-code",
+                params={"url": value_set_url, "system": system, "code": code},
+            )
+            if response.status_code != 200:
+                logger.debug(
+                    "Terminology validate-code failed: HTTP %d", response.status_code
+                )
+                return True  # permissive on error
+
+            data = response.json()
+            result = self._extract_boolean_from_parameters(data, "result")
+            self._validate_cache[cache_key] = result
+            return result
+        except Exception as e:
+            logger.debug("Terminology validate-code error: %s", e)
+            return True  # permissive on error
+
+    async def expand(
+        self,
+        value_set_url: str,
+        filter: str | None = None,
+        count: int = 200,
+    ) -> dict:
+        """Return FHIR ValueSet $expand response as dict."""
+        try:
+            client = self._ensure_client()
+            params: dict[str, str | int] = {"url": value_set_url, "count": count}
+            if filter:
+                params["filter"] = filter
+
+            response = await client.get("/ValueSet/$expand", params=params)
+            if response.status_code != 200:
+                logger.warning(
+                    "Terminology expand failed for %s: HTTP %d",
+                    value_set_url, response.status_code,
+                )
+                return {"resourceType": "OperationOutcome", "issue": [{
+                    "severity": "error",
+                    "code": "exception",
+                    "diagnostics": f"Upstream returned HTTP {response.status_code}",
+                }]}
+
+            return response.json()
+        except Exception as e:
+            logger.warning("Terminology expand error for %s: %s", value_set_url, e)
+            return {"resourceType": "OperationOutcome", "issue": [{
+                "severity": "error",
+                "code": "exception",
+                "diagnostics": str(e),
+            }]}
+
+    async def health_check(self) -> tuple[str, int | None]:
+        """Check upstream connectivity. Returns (status, response_ms)."""
+        try:
+            client = self._ensure_client()
+            start = time.monotonic()
+            response = await client.get("/metadata", params={"_summary": "true"})
+            elapsed_ms = int((time.monotonic() - start) * 1000)
+
+            if response.status_code == 200:
+                if elapsed_ms > 2000:
+                    return "degraded", elapsed_ms
+                return "online", elapsed_ms
+            return "offline", elapsed_ms
+        except Exception:
+            return "offline", None
+
+    @staticmethod
+    def _extract_display_from_parameters(data: dict) -> str | None:
+        """Extract display value from a FHIR Parameters response."""
+        for param in data.get("parameter", []):
+            if param.get("name") == "display":
+                return param.get("valueString")
+        return None
+
+    @staticmethod
+    def _extract_boolean_from_parameters(data: dict, name: str) -> bool:
+        """Extract a boolean parameter from a FHIR Parameters response."""
+        for param in data.get("parameter", []):
+            if param.get("name") == name:
+                return param.get("valueBoolean", False)
+        return False
+
+
+terminology_client = TerminologyClient()

--- a/api/src/terminology/enrichment.py
+++ b/api/src/terminology/enrichment.py
@@ -1,0 +1,163 @@
+"""Composition enrichment: resolve coded display terms via terminology server.
+
+Walks an openEHR composition JSON tree (STRUCTURED format) and populates
+DV_CODED_TEXT.value fields that are missing or contain raw codes.
+"""
+
+import asyncio
+import copy
+import logging
+import re
+from typing import Any
+
+from src.terminology.client import TerminologyClient
+from src.terminology.systems import INTERNAL_TERMINOLOGIES, to_fhir_system
+
+logger = logging.getLogger(__name__)
+
+# Pattern that looks like a raw code rather than a display term
+_RAW_CODE_PATTERN = re.compile(r"^\d[\d.\-]*$")
+
+
+def _looks_like_raw_code(value: str) -> bool:
+    """Return True if the value looks like a raw code rather than a display term."""
+    return bool(_RAW_CODE_PATTERN.match(value))
+
+
+def _collect_coded_text_nodes(
+    data: Any, results: list[dict[str, Any]]
+) -> None:
+    """Recursively find DV_CODED_TEXT nodes that need display term enrichment."""
+    if isinstance(data, dict):
+        if data.get("_type") == "DV_CODED_TEXT":
+            defining_code = data.get("defining_code", {})
+            terminology_id = defining_code.get("terminology_id", {}).get("value", "")
+            code_string = defining_code.get("code_string", "")
+            current_value = data.get("value", "")
+
+            if (
+                terminology_id.lower() not in INTERNAL_TERMINOLOGIES
+                and code_string
+                and (not current_value or _looks_like_raw_code(current_value))
+            ):
+                fhir_system = to_fhir_system(terminology_id)
+                if fhir_system:
+                    results.append({
+                        "node": data,
+                        "system": fhir_system,
+                        "code": code_string,
+                    })
+
+        for v in data.values():
+            _collect_coded_text_nodes(v, results)
+    elif isinstance(data, list):
+        for item in data:
+            _collect_coded_text_nodes(item, results)
+
+
+async def enrich_composition(
+    composition: dict[str, Any],
+    client: TerminologyClient,
+) -> dict[str, Any]:
+    """Enrich DV_CODED_TEXT display terms in a composition (STRUCTURED format).
+
+    Returns a deep copy with resolved display terms.
+    The original composition is never modified.
+    Failures are silent — unresolved codes keep their original value.
+    """
+    enriched = copy.deepcopy(composition)
+
+    nodes: list[dict[str, Any]] = []
+    _collect_coded_text_nodes(enriched, nodes)
+
+    if not nodes:
+        return enriched
+
+    # Deduplicate lookups by (system, code)
+    unique_pairs = list({(n["system"], n["code"]) for n in nodes})
+    logger.debug("Enriching %d unique codes from %d nodes", len(unique_pairs), len(nodes))
+
+    # Batch-resolve all unique codes concurrently
+    results = await asyncio.gather(
+        *[client.lookup(system, code) for system, code in unique_pairs],
+        return_exceptions=True,
+    )
+
+    # Build lookup map
+    resolved: dict[tuple[str, str], str | None] = {}
+    for pair, result in zip(unique_pairs, results, strict=True):
+        if isinstance(result, BaseException):
+            logger.debug("Lookup failed for %s: %s", pair, result)
+            resolved[pair] = None
+        else:
+            resolved[pair] = result
+
+    # Apply resolved display terms
+    for node_info in nodes:
+        display = resolved.get((node_info["system"], node_info["code"]))
+        if display:
+            node_info["node"]["value"] = display
+
+    return enriched
+
+
+async def enrich_flat_composition(
+    composition: dict[str, Any],
+    client: TerminologyClient,
+) -> dict[str, Any]:
+    """Enrich coded values in a FLAT format composition.
+
+    FLAT format stores codes as path|code, path|value, path|terminology pairs.
+    This function looks for paths where |value is missing or looks like a raw code,
+    and resolves it via the terminology server.
+
+    Returns a copy with resolved display terms.
+    """
+    enriched = dict(composition)
+
+    # Find paths with |code suffix that might need enrichment
+    code_paths: dict[str, tuple[str, str]] = {}  # base_path → (terminology, code)
+    for key, value in composition.items():
+        if key.endswith("|code") and isinstance(value, str):
+            base_path = key[: -len("|code")]
+            terminology_key = f"{base_path}|terminology"
+            value_key = f"{base_path}|value"
+
+            terminology = composition.get(terminology_key, "")
+            current_value = composition.get(value_key, "")
+
+            if (
+                terminology
+                and terminology.lower() not in INTERNAL_TERMINOLOGIES
+                and (
+                    not current_value
+                    or _looks_like_raw_code(str(current_value))
+                    or str(current_value) == value  # value == code means unresolved
+                )
+            ):
+                fhir_system = to_fhir_system(terminology)
+                if fhir_system:
+                    code_paths[base_path] = (fhir_system, value)
+
+    if not code_paths:
+        return enriched
+
+    unique_pairs = list(set(code_paths.values()))
+    results = await asyncio.gather(
+        *[client.lookup(system, code) for system, code in unique_pairs],
+        return_exceptions=True,
+    )
+
+    resolved: dict[tuple[str, str], str | None] = {}
+    for pair, result in zip(unique_pairs, results, strict=True):
+        if isinstance(result, BaseException):
+            resolved[pair] = None
+        else:
+            resolved[pair] = result
+
+    for base_path, pair in code_paths.items():
+        display = resolved.get(pair)
+        if display:
+            enriched[f"{base_path}|value"] = display
+
+    return enriched

--- a/api/src/terminology/router.py
+++ b/api/src/terminology/router.py
@@ -1,0 +1,125 @@
+"""Terminology API endpoints: health check and FHIR pass-through."""
+
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
+
+from src.config import settings
+from src.terminology.client import terminology_client
+from src.terminology.schemas import CodeLookupResponse, TerminologyHealthResponse
+
+router = APIRouter()
+
+
+# ============================================================================
+# Health Check
+# ============================================================================
+
+
+@router.get("/health", response_model=TerminologyHealthResponse)
+async def terminology_health() -> TerminologyHealthResponse:
+    """Check connectivity to the upstream FHIR terminology server."""
+    if not settings.terminology_enabled:
+        return TerminologyHealthResponse(
+            status="offline", url=settings.terminology_server_url, response_ms=None
+        )
+
+    status, response_ms = await terminology_client.health_check()
+    return TerminologyHealthResponse(
+        status=status,
+        url=settings.terminology_server_url,
+        response_ms=response_ms,
+    )
+
+
+# ============================================================================
+# FHIR Pass-Through Endpoints
+# ============================================================================
+
+
+fhir_router = APIRouter()
+
+
+@fhir_router.get("/CodeSystem/$lookup", response_model=CodeLookupResponse)
+async def code_lookup(
+    system: str = Query(..., description="Code system URI (e.g. http://snomed.info/sct)"),
+    code: str = Query(..., description="Code to look up"),
+) -> CodeLookupResponse:
+    """Look up a code's display term via the upstream terminology server."""
+    display = await terminology_client.lookup(system, code)
+    return CodeLookupResponse(
+        system=system,
+        code=code,
+        display=display,
+        found=display is not None,
+    )
+
+
+@fhir_router.get("/ValueSet/$expand")
+async def valueset_expand(
+    url: str = Query(..., description="Canonical ValueSet URL"),
+    filter: str | None = Query(None, description="Text filter for expansion"),
+    count: int = Query(200, ge=1, le=1000, description="Max concepts to return"),
+) -> JSONResponse:
+    """Expand a ValueSet via the upstream terminology server.
+
+    Returns raw FHIR ValueSet JSON for direct consumption by medblocks-ui components.
+    """
+    result = await terminology_client.expand(url, filter=filter, count=count)
+    return JSONResponse(content=result, media_type="application/fhir+json")
+
+
+@fhir_router.get("/ValueSet/{value_set_id}/$expand")
+async def valueset_expand_by_id(
+    value_set_id: str,
+    filter: str | None = Query(None, description="Text filter for expansion"),
+    count: int = Query(200, ge=1, le=1000, description="Max concepts to return"),
+) -> JSONResponse:
+    """Expand a ValueSet by ID via the upstream terminology server.
+
+    Proxies to the upstream server's ValueSet/{id}/$expand endpoint.
+    """
+    try:
+        client = terminology_client._ensure_client()
+        params: dict[str, str | int] = {"count": count}
+        if filter:
+            params["filter"] = filter
+
+        response = await client.get(f"/ValueSet/{value_set_id}/$expand", params=params)
+        return JSONResponse(
+            content=response.json(),
+            status_code=response.status_code,
+            media_type="application/fhir+json",
+        )
+    except Exception as e:
+        return JSONResponse(
+            content={
+                "resourceType": "OperationOutcome",
+                "issue": [{
+                    "severity": "error",
+                    "code": "exception",
+                    "diagnostics": str(e),
+                }],
+            },
+            status_code=502,
+            media_type="application/fhir+json",
+        )
+
+
+@fhir_router.get("/ValueSet/$validate-code")
+async def valueset_validate_code(
+    url: str = Query(..., description="Canonical ValueSet URL"),
+    system: str = Query(..., description="Code system URI"),
+    code: str = Query(..., description="Code to validate"),
+) -> JSONResponse:
+    """Validate whether a code belongs to a ValueSet.
+
+    Returns a FHIR Parameters response.
+    """
+    result = await terminology_client.validate_code(url, system, code)
+    return JSONResponse(
+        content={
+            "resourceType": "Parameters",
+            "parameter": [{"name": "result", "valueBoolean": result}],
+        },
+        media_type="application/fhir+json",
+    )

--- a/api/src/terminology/schemas.py
+++ b/api/src/terminology/schemas.py
@@ -1,0 +1,16 @@
+"""Response schemas for terminology endpoints."""
+
+from pydantic import BaseModel, Field
+
+
+class TerminologyHealthResponse(BaseModel):
+    status: str = Field(..., description="online | degraded | offline")
+    url: str = Field(..., description="Configured terminology server URL")
+    response_ms: int | None = Field(None, description="Response time in milliseconds")
+
+
+class CodeLookupResponse(BaseModel):
+    system: str
+    code: str
+    display: str | None = None
+    found: bool

--- a/api/src/terminology/systems.py
+++ b/api/src/terminology/systems.py
@@ -1,0 +1,27 @@
+"""Mapping between openEHR terminology identifiers and FHIR system URIs."""
+
+# openEHR terminology_id.value → FHIR canonical system URI
+OPENEHR_TO_FHIR_SYSTEM: dict[str, str] = {
+    "SNOMED-CT": "http://snomed.info/sct",
+    "LOINC": "http://loinc.org",
+    "ATC": "http://www.whocc.no/atc",
+    "ICD10": "http://hl7.org/fhir/sid/icd-10",
+    "ICD10-CM": "http://hl7.org/fhir/sid/icd-10-cm",
+}
+
+# Internal terminologies that should not be looked up
+INTERNAL_TERMINOLOGIES: set[str] = {"openehr", "local"}
+
+
+def to_fhir_system(openehr_terminology_id: str) -> str | None:
+    """Convert an openEHR terminology identifier to a FHIR system URI.
+
+    Returns None for internal terminologies (openehr, local) that should be skipped.
+    If the identifier is already a URI (starts with http), return it as-is.
+    """
+    lower = openehr_terminology_id.lower()
+    if lower in INTERNAL_TERMINOLOGIES:
+        return None
+    if openehr_terminology_id.startswith("http"):
+        return openehr_terminology_id
+    return OPENEHR_TO_FHIR_SYSTEM.get(openehr_terminology_id)

--- a/api/tests/unit/conftest.py
+++ b/api/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+"""Conftest for unit tests that do not require database or external services."""
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    """Override the root conftest setup_db — no database needed for unit tests."""
+    yield

--- a/api/tests/unit/test_terminology.py
+++ b/api/tests/unit/test_terminology.py
@@ -1,5 +1,7 @@
 """Tests for the FHIR terminology client, enrichment, and system mapping."""
 
+from typing import Any
+
 import httpx
 import pytest
 
@@ -292,7 +294,7 @@ class TestEnrichment:
             base_url="http://test-tx",
         )
 
-        composition = {
+        composition: dict[str, Any] = {
             "_type": "COMPOSITION",
             "content": [
                 {

--- a/api/tests/unit/test_terminology.py
+++ b/api/tests/unit/test_terminology.py
@@ -1,0 +1,421 @@
+"""Tests for the FHIR terminology client, enrichment, and system mapping."""
+
+import httpx
+import pytest
+
+from src.terminology.client import TerminologyClient
+from src.terminology.enrichment import enrich_composition, enrich_flat_composition
+from src.terminology.systems import INTERNAL_TERMINOLOGIES, to_fhir_system
+
+
+class TestSystemMapping:
+    """Test openEHR → FHIR system URI mapping."""
+
+    def test_snomed_ct_mapping(self):
+        assert to_fhir_system("SNOMED-CT") == "http://snomed.info/sct"
+
+    def test_loinc_mapping(self):
+        assert to_fhir_system("LOINC") == "http://loinc.org"
+
+    def test_atc_mapping(self):
+        assert to_fhir_system("ATC") == "http://www.whocc.no/atc"
+
+    def test_icd10_mapping(self):
+        assert to_fhir_system("ICD10") == "http://hl7.org/fhir/sid/icd-10"
+
+    def test_internal_openehr_returns_none(self):
+        assert to_fhir_system("openehr") is None
+
+    def test_internal_local_returns_none(self):
+        assert to_fhir_system("local") is None
+
+    def test_http_uri_passthrough(self):
+        uri = "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"
+        assert to_fhir_system(uri) == uri
+
+    def test_unknown_returns_none(self):
+        assert to_fhir_system("UNKNOWN-SYSTEM") is None
+
+    def test_internal_terminologies_set(self):
+        assert "openehr" in INTERNAL_TERMINOLOGIES
+        assert "local" in INTERNAL_TERMINOLOGIES
+
+
+class TestTerminologyClientLookup:
+    """Test TerminologyClient.lookup with mocked transport."""
+
+    @pytest.mark.asyncio
+    async def test_lookup_returns_display(self):
+        """Test that lookup extracts display from FHIR Parameters response."""
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "resourceType": "Parameters",
+                    "parameter": [
+                        {"name": "display", "valueString": "Observable entity"},
+                        {"name": "name", "valueString": "Observable entity"},
+                    ],
+                },
+            )
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        result = await client.lookup("http://snomed.info/sct", "363787002")
+        assert result == "Observable entity"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_lookup_caches_result(self):
+        """Test that repeated lookups use the cache."""
+        import httpx
+
+        call_count = 0
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(
+                200,
+                json={
+                    "resourceType": "Parameters",
+                    "parameter": [
+                        {"name": "display", "valueString": "Test display"},
+                    ],
+                },
+            )
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        r1 = await client.lookup("http://snomed.info/sct", "12345")
+        r2 = await client.lookup("http://snomed.info/sct", "12345")
+
+        assert r1 == "Test display"
+        assert r2 == "Test display"
+        assert call_count == 1  # Only one HTTP call — second was cached
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_lookup_returns_none_on_404(self):
+        """Test that lookup returns None for unknown codes."""
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"resourceType": "OperationOutcome"})
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        result = await client.lookup("http://snomed.info/sct", "999999999")
+        assert result is None
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_lookup_returns_none_on_network_error(self):
+        """Test that lookup fails silently on network errors."""
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("Connection refused")
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        result = await client.lookup("http://snomed.info/sct", "12345")
+        assert result is None
+        await client.close()
+
+
+class TestTerminologyClientValidateCode:
+    """Test TerminologyClient.validate_code."""
+
+    @pytest.mark.asyncio
+    async def test_validate_code_returns_true(self):
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "resourceType": "Parameters",
+                    "parameter": [{"name": "result", "valueBoolean": True}],
+                },
+            )
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        result = await client.validate_code(
+            "http://example.com/ValueSet/test",
+            "http://snomed.info/sct",
+            "12345",
+        )
+        assert result is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_validate_code_returns_false(self):
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "resourceType": "Parameters",
+                    "parameter": [{"name": "result", "valueBoolean": False}],
+                },
+            )
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        result = await client.validate_code(
+            "http://example.com/ValueSet/test",
+            "http://snomed.info/sct",
+            "99999",
+        )
+        assert result is False
+        await client.close()
+
+
+class TestTerminologyClientExpand:
+    """Test TerminologyClient.expand."""
+
+    @pytest.mark.asyncio
+    async def test_expand_returns_valueset(self):
+        import httpx
+
+        from src.terminology.client import TerminologyClient
+
+        valueset_response = {
+            "resourceType": "ValueSet",
+            "expansion": {
+                "contains": [
+                    {
+                        "system": "http://snomed.info/sct",
+                        "code": "840539006",
+                        "display": "COVID-19 vaccine",
+                    }
+                ]
+            },
+        }
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=valueset_response)
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        result = await client.expand("http://example.com/ValueSet/vaccines")
+        assert result["resourceType"] == "ValueSet"
+        assert len(result["expansion"]["contains"]) == 1
+        await client.close()
+
+
+class TestTerminologyHealthCheck:
+    """Test TerminologyClient.health_check."""
+
+    @pytest.mark.asyncio
+    async def test_health_check_online(self):
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"resourceType": "CapabilityStatement"})
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        status, ms = await client.health_check()
+        assert status == "online"
+        assert ms is not None
+        assert ms >= 0
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_health_check_offline_on_error(self):
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("Connection refused")
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        status, ms = await client.health_check()
+        assert status == "offline"
+        assert ms is None
+        await client.close()
+
+
+class TestEnrichment:
+    """Test composition enrichment."""
+
+    @pytest.mark.asyncio
+    async def test_enrich_composition_structured(self):
+        """Test enrichment of STRUCTURED format DV_CODED_TEXT nodes."""
+        import httpx
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            url = str(request.url)
+            if "363787002" in url:
+                return httpx.Response(
+                    200,
+                    json={
+                        "resourceType": "Parameters",
+                        "parameter": [
+                            {"name": "display", "valueString": "Observable entity"},
+                        ],
+                    },
+                )
+            return httpx.Response(404, json={})
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        composition = {
+            "_type": "COMPOSITION",
+            "content": [
+                {
+                    "_type": "DV_CODED_TEXT",
+                    "value": "363787002",
+                    "defining_code": {
+                        "_type": "CODE_PHRASE",
+                        "terminology_id": {"value": "SNOMED-CT"},
+                        "code_string": "363787002",
+                    },
+                }
+            ],
+        }
+
+        result = await enrich_composition(composition, client)
+
+        # Original should be unchanged
+        assert composition["content"][0]["value"] == "363787002"
+        # Enriched copy should have display term
+        assert result["content"][0]["value"] == "Observable entity"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_enrich_skips_local_terminology(self):
+        """Test that internal terminologies (local, openehr) are skipped."""
+        import httpx
+
+        from src.terminology.client import TerminologyClient
+        from src.terminology.enrichment import enrich_composition
+
+        call_count = 0
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json={})
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        composition = {
+            "_type": "DV_CODED_TEXT",
+            "value": "",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {"value": "local"},
+                "code_string": "at0001",
+            },
+        }
+
+        result = await enrich_composition(composition, client)
+        assert call_count == 0  # No HTTP calls for local terminology
+        assert result["value"] == ""
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_enrich_flat_composition(self):
+        """Test enrichment of FLAT format compositions."""
+        import httpx
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "resourceType": "Parameters",
+                    "parameter": [
+                        {"name": "display", "valueString": "High"},
+                    ],
+                },
+            )
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        flat = {
+            "some_path/interpretation|code": "H",
+            "some_path/interpretation|value": "H",
+            "some_path/interpretation|terminology": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+            "some_path/magnitude|magnitude": 150,
+        }
+
+        result = await enrich_flat_composition(flat, client)
+        assert result["some_path/interpretation|value"] == "High"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_enrich_preserves_existing_display(self):
+        """Test that nodes with proper display terms are not overwritten."""
+        import httpx
+
+        from src.terminology.client import TerminologyClient
+        from src.terminology.enrichment import enrich_composition
+
+        call_count = 0
+
+        def mock_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            return httpx.Response(200, json={})
+
+        client = TerminologyClient()
+        client._client = httpx.AsyncClient(
+            transport=httpx.MockTransport(mock_handler),
+            base_url="http://test-tx",
+        )
+
+        composition = {
+            "_type": "DV_CODED_TEXT",
+            "value": "Already has a proper display term",
+            "defining_code": {
+                "_type": "CODE_PHRASE",
+                "terminology_id": {"value": "SNOMED-CT"},
+                "code_string": "12345",
+            },
+        }
+
+        result = await enrich_composition(composition, client)
+        assert call_count == 0  # No lookup needed
+        assert result["value"] == "Already has a proper display term"
+        await client.close()

--- a/docs/prd/0012-fhir-terminology-integration.md
+++ b/docs/prd/0012-fhir-terminology-integration.md
@@ -1,0 +1,377 @@
+# PRD-0012: FHIR Terminology Server Integration
+
+**Version:** 1.1
+**Date:** 2026-04-10
+**Status:** Draft
+**Owner:** Open CIS Project
+**Priority:** P2 (Required for CH VACD / vaccination showcase)
+
+---
+
+## Executive Summary
+
+Integrate a FHIR-compatible terminology server into Open CIS to enable human-readable display of coded clinical values stored in openEHR compositions. openEHR archetypes embed SNOMED CT, LOINC, and other coded terminologies as raw `CODE_PHRASE` values (code + terminology ID). Without a terminology server, these codes are opaque to end users and to the FHIR interoperability layer. This PRD specifies a lightweight, server-side terminology client backed initially by the public Swiss FHIR terminology server (`https://tx.fhir.ch/r4`), with an optional self-hosted path for future production use.
+
+---
+
+## Problem Statement
+
+### The Core Gap
+
+When openEHR compositions are stored in EHRBase, coded values appear as raw `CODE_PHRASE` structures:
+
+```json
+{
+  "_type": "DV_CODED_TEXT",
+  "value": "363787002",
+  "defining_code": {
+    "_type": "CODE_PHRASE",
+    "terminology_id": { "value": "SNOMED-CT" },
+    "code_string": "363787002"
+  }
+}
+```
+
+The `value` field should carry the human-readable display term (e.g., *"Observable entity"*), but this is not always populated, especially in compositions built programmatically via oehrpy's `ImmunizationBuilder` or created from the CH VACD vaccination template. Without resolved display terms:
+
+1. The **Composition Viewer** in Open CIS shows raw SNOMED/LOINC codes to clinical users — unacceptable for real clinical workflows.
+2. The **FHIR API layer** (`/api/fhir/...`, ADR-0004) must emit `Coding.display` on FHIR resources it produces. Without terminology resolution, it either omits `display` (non-conformant) or guesses (unsafe).
+3. The **CH VACD vaccination showcase** (PRD-0005) references Swiss-specific value sets (e.g., `http://fhir.ch/ig/ch-vacd/ValueSet/ch-vacd-vaccines-vs`). Validating that a recorded vaccine code belongs to the correct value set requires a terminology server.
+4. The **SMART on FHIR vaccination app** (PRD-0006) uses medblocks-ui components that can bind to FHIR ValueSet `$expand` responses to populate dropdown choices. Without a terminology server endpoint, these dropdowns cannot be populated dynamically.
+
+### Affected Terminology Systems
+
+| System | Identifier in openEHR | Example codes |
+|---|---|---|
+| SNOMED CT | `SNOMED-CT` | `363787002`, `840539006` (COVID-19 vaccine) |
+| LOINC | `LOINC` | `59408-5` (SpO2), `8480-6` (systolic BP) |
+| ATC (drugs) | `ATC` | `J07BX03` (COVID-19 vaccine) |
+| Swiss CH VACD value sets | FHIR canonical URL | `http://fhir.ch/ig/ch-vacd/ValueSet/ch-vacd-vaccines-vs` |
+| HL7 observation interpretation | `http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation` | `L` (low), `H` (high) |
+
+---
+
+## Goals
+
+1. Provide a thin `TerminologyService` in FastAPI that proxies FHIR `$lookup` and `$validate-code` / `ValueSet/$expand` calls to a configured upstream FHIR terminology server.
+2. Use `https://tx.fhir.ch/r4` as the **default upstream** — publicly available, no auth, covers SNOMED CT, LOINC, ATC, and Swiss national value sets (CH VACD, CH Core).
+3. Expose resolved display terms in composition API responses without blocking on terminology calls (lazy / on-demand resolution per the established Open CIS UX principle).
+4. Expose a `GET /api/fhir/terminology/...` pass-through surface for use by medblocks-ui ValueSet `$expand` requests from the Vue frontend (PRD-0006).
+5. Design the configuration so that swapping the upstream to a self-hosted Snowstorm Lite instance (ADR-0003) requires only an environment variable change, with zero code changes.
+
+---
+
+## Non-Goals
+
+- Self-hosting a terminology server is **out of scope** for this PRD. That is deferred to a future ADR/PRD once production usage justifies it.
+- Providing a full FHIR terminology server proxy (all operations) is out of scope. Only `CodeSystem/$lookup`, `ValueSet/$validate-code`, and `ValueSet/$expand` are required.
+- Caching terminology data to a persistent store (database) is out of scope for v1. In-memory TTL cache is sufficient.
+
+---
+
+## Where Terminology Resolution Helps in the Current Codebase
+
+### 1. Composition Viewer — `GET /api/patients/{id}/compositions/{uid}`
+
+**Location:** `api/src/compositions/router.py` → response model
+
+**Problem:** The composition detail endpoint returns the raw openEHR JSON from EHRBase. `DV_CODED_TEXT` nodes carry a `defining_code.code_string` but `value` (the display term) may be missing or stale.
+
+**Solution:** A post-processing step in the FastAPI response enriches `DV_CODED_TEXT` nodes whose `value` is empty or numeric-looking by calling `CodeSystem/$lookup` for each unique code. This is done asynchronously with `asyncio.gather` and is bounded by an in-memory TTL cache so repeated renders of the same composition are fast.
+
+**Benefit:** Clinical users see *"COVID-19 vaccine"* instead of `840539006`.
+
+---
+
+### 2. Vital Signs Chart — Observation interpretation codes
+
+**Location:** `api/src/observations/router.py`
+
+**Problem:** The IDCR Vital Signs template includes `DV_CODED_TEXT` interpretation fields using `http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation` (e.g. `L`, `H`, `N`). These are stored as code-only in EHRBase compositions.
+
+**Solution:** `$lookup` against the Swiss terminology server (which mirrors HL7 terminology code systems) resolves `L` → *"Low"*, `H` → *"High"*, etc. The resolved display is returned alongside the magnitude in the chart data payload.
+
+---
+
+### 3. CH VACD Vaccination Showcase — `POST /api/patients/{id}/vaccinations` (PRD-0005)
+
+**Location:** `api/src/vaccinations/router.py` (to be created per PRD-0005)
+
+**Problem:** Vaccine codes submitted by the user (ATC codes like `J07BX03`, or SNOMED vaccine product codes) need to be validated as members of the CH VACD vaccine value set before being written to EHRBase. Without a terminology server, this validation is absent or requires maintaining a local static list.
+
+**Solution:** Call `ValueSet/$validate-code` on `http://fhir.ch/ig/ch-vacd/ValueSet/ch-vacd-vaccines-vs` at the Swiss terminology server. Reject compositions that contain out-of-set codes with a `422 Unprocessable Entity` response and a descriptive error.
+
+**Benefit:** Data quality gate enforced at the API layer, consistent with the CH VACD IG profile requirements.
+
+---
+
+### 4. FHIR API Layer — `/api/fhir/Immunization` (PRD-0006)
+
+**Location:** `api/src/fhir/immunization.py` (to be created per PRD-0006)
+
+**Problem:** When openFHIR translates an openEHR vaccination composition to a FHIR `Immunization` resource, the `vaccineCode.coding[].display` field must be populated for conformance to the CH VACD FHIR IG. openFHIR produces the mapping but does not call a terminology server to fill `display`.
+
+**Solution:** A post-processing enrichment step in the FHIR router calls `CodeSystem/$lookup` for each `coding` element that is missing `display` before returning the FHIR resource to the caller.
+
+---
+
+### 5. medblocks-ui Dropdowns — `GET /api/fhir/ValueSet/$expand` (PRD-0006)
+
+**Location:** `api/src/fhir/terminology.py` (new, this PRD)
+
+**Problem:** medblocks-ui Web Components (e.g., `<mb-select>`) accept a FHIR `ValueSet/$expand` URL to populate their option lists. The component must call a FHIR-compatible endpoint. Open CIS's own domain is the appropriate origin to avoid CORS issues and to allow transparent upstream switching.
+
+**Solution:** Expose `GET /api/fhir/ValueSet/{id}/$expand` (and `GET /api/fhir/CodeSystem/{id}/$lookup`) as thin, authenticated pass-throughs to the configured upstream. The Vue frontend configures medblocks-ui components with `terminologyUrl: "/api/fhir"`.
+
+---
+
+## Architecture
+
+### Components
+
+```
+Vue 3 frontend
+    │
+    │  GET /api/patients/{id}/compositions/{uid}  (enriched)
+    │  GET /api/fhir/ValueSet/{id}/$expand        (pass-through)
+    ▼
+FastAPI (Open CIS API)
+    ├── TerminologyService  ←─── TerminologyClient (httpx, async)
+    │       ├── lookup(system, code) → display_term
+    │       ├── validate_code(value_set_url, system, code) → bool
+    │       └── expand(value_set_url, filter?) → ValueSet
+    │                │
+    │                └──► https://tx.fhir.ch/r4   (default upstream)
+    │                      (swap to Snowstorm Lite via env var)
+    │
+    ├── CompositionRouter   — enriches DV_CODED_TEXT display terms
+    ├── VaccinationRouter   — calls validate_code before EHRBase write
+    └── FhirRouter          — pass-through + enriches Immunization.display
+```
+
+### Configuration
+
+```python
+# api/src/config.py (additions)
+TERMINOLOGY_SERVER_URL: str = "https://tx.fhir.ch/r4"
+TERMINOLOGY_CACHE_TTL_SECONDS: int = 3600
+TERMINOLOGY_ENABLED: bool = True
+```
+
+Switching to self-hosted Snowstorm Lite:
+
+```bash
+TERMINOLOGY_SERVER_URL=http://snowstorm:8080/fhir
+```
+
+No code changes required.
+
+### TerminologyClient
+
+```python
+# api/src/terminology/client.py
+
+class TerminologyClient:
+    """Async FHIR R4 terminology client backed by httpx."""
+
+    async def lookup(
+        self,
+        system: str,           # e.g. "http://snomed.info/sct"
+        code: str,
+    ) -> str | None:
+        """Return display term for a code, or None if not found."""
+
+    async def validate_code(
+        self,
+        value_set_url: str,    # canonical FHIR ValueSet URL
+        system: str,
+        code: str,
+    ) -> bool:
+        """Return True if code is a member of the given ValueSet."""
+
+    async def expand(
+        self,
+        value_set_url: str,
+        filter: str | None = None,
+        count: int = 200,
+    ) -> dict:
+        """Return FHIR ValueSet $expand response as dict."""
+```
+
+### System identifier normalisation
+
+openEHR compositions use short identifiers (`SNOMED-CT`, `LOINC`). FHIR uses canonical URIs. A translation table is required:
+
+| openEHR `terminology_id` | FHIR `system` URI |
+|---|---|
+| `SNOMED-CT` | `http://snomed.info/sct` |
+| `LOINC` | `http://loinc.org` |
+| `ATC` | `http://www.whocc.no/atc` |
+| `ICD10` | `http://hl7.org/fhir/sid/icd-10` |
+| `openehr` | *(internal, skip)* |
+| `local` | *(internal, skip)* |
+
+This mapping lives in `api/src/terminology/systems.py` as a simple `dict[str, str]`.
+
+### In-memory cache
+
+Use `cachetools.TTLCache` keyed on `(system_uri, code)` for `$lookup` results and `(value_set_url, system_uri, code)` for `$validate-code` results. Default TTL: 1 hour. No Redis dependency for v1.
+
+```python
+from cachetools import TTLCache
+_lookup_cache: TTLCache[tuple[str, str], str | None] = TTLCache(
+    maxsize=10_000, ttl=TERMINOLOGY_CACHE_TTL_SECONDS
+)
+```
+
+### Lazy enrichment pattern
+
+Composition enrichment happens **after** the composition is fetched from EHRBase, in the API response handler — not in the CDR write path. This is consistent with the lazy resolution principle established across the project. The enrichment step:
+
+1. Walks the composition JSON tree for `DV_CODED_TEXT` nodes where `defining_code.terminology_id.value` is not `local` or `openehr` and `value` is absent or matches a raw code pattern.
+2. Collects unique `(system, code)` pairs.
+3. Fires `asyncio.gather(*[client.lookup(s, c) for s, c in unique_pairs])` — a single concurrent batch.
+4. Patches the `value` fields in the composition copy returned to the client. The raw composition stored in EHRBase is never modified.
+
+---
+
+## System Page Integration
+
+The Open CIS system/status page must display the terminology server as a first-class infrastructure component alongside EHRBase and other services.
+
+### Display Requirements
+
+The terminology server card on the system page shows:
+
+- **URL** — the configured `TERMINOLOGY_SERVER_URL` value
+- **Status** — live connectivity indicator, resolved by calling `GET /api/terminology/health` on page load. States: `online` (green), `degraded` (yellow, reachable but slow > 2s), `offline` (red, timeout or 5xx)
+- **Upstream type** — derived from the URL: `Swiss FHIR Terminology Server (tx.fhir.ch)` for the default, `Snowstorm Lite (self-hosted)` if the URL matches a local host, or the raw hostname for any other value
+- **Relations to other components** — a brief list of which Open CIS features depend on it:
+  - Composition Viewer — display term enrichment
+  - Vital Signs — observation interpretation labels
+  - Vaccinations — CH VACD value set validation (shown only if PRD-0005 feature is active)
+  - FHIR API — `Coding.display` enrichment and ValueSet `$expand` pass-through (shown only if FHIR API feature is active)
+
+### Backend
+
+The existing `GET /api/terminology/health` endpoint (defined in the API Surface section above) is the sole backend requirement. It returns:
+
+```json
+{
+  "status": "online" | "degraded" | "offline",
+  "url": "https://tx.fhir.ch/r4",
+  "response_ms": 312
+}
+```
+
+The frontend polls this endpoint once on system page mount; no WebSocket or background polling is required.
+
+---
+
+## API Surface
+
+### New endpoints (this PRD)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/fhir/ValueSet/{id}/$expand` | Pass-through ValueSet expand to upstream |
+| `GET` | `/api/fhir/ValueSet/$expand?url={url}` | Pass-through ValueSet expand by canonical URL |
+| `GET` | `/api/fhir/CodeSystem/$lookup?system={s}&code={c}` | Pass-through code lookup |
+| `GET` | `/api/terminology/health` | Connectivity check against upstream |
+
+### Modified endpoints
+
+| Method | Path | Change |
+|---|---|---|
+| `GET` | `/api/patients/{id}/compositions/{uid}` | `DV_CODED_TEXT.value` enriched on response |
+| `GET` | `/api/patients/{id}/vitals` | Interpretation codes resolved to display terms |
+
+---
+
+## Implementation Plan
+
+### Phase 1 — Core Client & Health Check (1–2 days)
+
+- Add `httpx` async client dependency.
+- Implement `TerminologyClient` with `lookup`, `validate_code`, `expand`.
+- Implement `systems.py` normalisation table.
+- Add `TTLCache` wrapper.
+- Add `GET /api/terminology/health` endpoint.
+- Add `TERMINOLOGY_SERVER_URL` env var to `docker-compose.yml` and `.env.example`.
+- Write unit tests with `httpx.MockTransport`.
+
+### Phase 2 — Composition Enrichment (1 day)
+
+- Implement `enrich_composition(composition_json, client)` utility in `api/src/terminology/enrichment.py`.
+- Wire into `GET /api/patients/{id}/compositions/{uid}` response handler.
+- Integration test: store a composition with a SNOMED code, retrieve it, assert `value` is populated.
+
+### Phase 3 — Vaccination Validation (tied to PRD-0005)
+
+- Add `validate_code` call in vaccination write path before EHRBase POST.
+- Return `422` with FHIR `OperationOutcome`-style error body on invalid code.
+- Wire CH VACD value set URL from config (not hard-coded).
+
+### Phase 4 — FHIR Pass-Through for medblocks-ui (tied to PRD-0006)
+
+- Implement `GET /api/fhir/ValueSet/{id}/$expand` and `GET /api/fhir/CodeSystem/$lookup` pass-throughs.
+- Add CORS header handling (pass-through must forward correct content-type).
+- Document medblocks-ui configuration in Open CIS frontend (`terminologyUrl: "/api/fhir"`).
+
+---
+
+## Configuration Reference
+
+| Variable | Default | Description |
+|---|---|---|
+| `TERMINOLOGY_SERVER_URL` | `https://tx.fhir.ch/r4` | Base URL of the FHIR R4 terminology server |
+| `TERMINOLOGY_ENABLED` | `true` | Feature flag — set `false` to disable all terminology calls |
+| `TERMINOLOGY_CACHE_TTL_SECONDS` | `3600` | TTL for in-memory lookup/validate cache |
+| `TERMINOLOGY_TIMEOUT_SECONDS` | `5` | HTTP timeout for upstream calls; failures are soft (log + skip) |
+
+**Failure mode:** If the terminology server is unreachable (timeout, 5xx), enrichment is skipped silently and the raw `code_string` is returned. The system must not fail a composition read because of a terminology server outage.
+
+---
+
+## Future Path to Self-Hosted Snowstorm Lite
+
+Per ADR-0003, Snowstorm Lite is the selected self-hosted option when Open CIS moves beyond the public server. The migration path is:
+
+1. Add `snowstorm-lite` container to `docker-compose.yml`.
+2. Load required SNOMED CT snapshot and CH extension into Snowstorm Lite at startup.
+3. Set `TERMINOLOGY_SERVER_URL=http://snowstorm-lite:8080/fhir` in the production `.env`.
+4. No application code changes required.
+
+Note: Snowstorm Lite does not cover LOINC or ATC by default. A mixed upstream strategy (route by `system` URI) may be needed if full terminology coverage is required in production.
+
+---
+
+## Success Criteria
+
+- `GET /api/patients/{id}/compositions/{uid}` returns `DV_CODED_TEXT.value` populated with human-readable display terms for SNOMED CT codes present in vital signs compositions.
+- A POST to the vaccination endpoint with a code outside the CH VACD vaccine value set returns `422`.
+- `GET /api/fhir/ValueSet/{id}/$expand` returns a valid FHIR ValueSet and can be consumed by a medblocks-ui `<mb-select>` component.
+- `GET /api/terminology/health` returns `200` when `tx.fhir.ch` is reachable.
+- Changing `TERMINOLOGY_SERVER_URL` to a local Snowstorm Lite instance requires no code changes.
+- The system page displays the terminology server card with URL, live status, and the list of dependent features.
+- Terminology server downtime does not degrade composition read availability (soft failure).
+
+---
+
+## Related Documents
+
+- [ADR-0003: Snowstorm Lite as Self-Hosted Terminology Server](../adr/ADR-0003-snowstorm-lite-terminology.md)
+- [ADR-0004: Two-Level API Surface (`/api` and `/api/fhir`)](../adr/ADR-0004-two-level-api-surface.md)
+- [PRD-0005: CH VACD Vaccination Showcase](PRD-0005-ch-vacd-vaccination.md)
+- [PRD-0006: SMART on FHIR Vaccination App](PRD-0006-smart-on-fhir.md)
+- Swiss FHIR Terminology Server: `https://tx.fhir.ch/r4`
+- Snowstorm Lite: `https://github.com/IHTSDO/snowstorm-lite`
+
+---
+
+## Change Log
+
+| Version | Date | Author | Changes |
+|---|---|---|---|
+| 1.0 | 2026-04-10 | Open CIS Team | Initial draft |
+| 1.1 | 2026-04-10 | Open CIS Team | Removed oehrpy and openEHR Explorer references; scope strictly Open CIS |

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -68,6 +68,7 @@ export default [
         document: 'readonly',
         navigator: 'readonly',
         fetch: 'readonly',
+        URL: 'readonly',
         URLSearchParams: 'readonly',
         RequestInit: 'readonly',
         Response: 'readonly',

--- a/web/src/components/system/SystemHealthDiagram.vue
+++ b/web/src/components/system/SystemHealthDiagram.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import type { HealthChecksSection } from '@/types'
+import type { HealthChecksSection, TerminologySection } from '@/types'
 
 defineProps<{
   healthChecks: HealthChecksSection
+  terminology: TerminologySection
 }>()
 
 function statusColor(itemStatus: string): string {
@@ -15,6 +16,31 @@ function statusLabel(item: { status: string; data: { status: string } | null }):
     return s.charAt(0).toUpperCase() + s.slice(1)
   }
   return 'Unavailable'
+}
+
+function terminologyStatusColor(status: string): string {
+  if (status === 'ok') return 'bg-green-500'
+  if (status === 'partial') return 'bg-yellow-500'
+  return 'bg-red-500'
+}
+
+function terminologyLabel(section: TerminologySection): string {
+  if (section.status === 'ok') return 'Online'
+  if (section.status === 'partial') return 'Degraded'
+  return 'Offline'
+}
+
+function terminologyHostname(section: TerminologySection): string {
+  if (!section.data?.url) return 'Not configured'
+  try {
+    const url = new URL(section.data.url)
+    if (url.hostname === 'tx.fhir.ch') return 'tx.fhir.ch (Swiss)'
+    if (['localhost', '127.0.0.1'].includes(url.hostname) || url.hostname.startsWith('snowstorm'))
+      return 'Self-hosted'
+    return url.hostname
+  } catch {
+    return section.data.url
+  }
 }
 </script>
 
@@ -80,6 +106,33 @@ function statusLabel(item: { status: string; data: { status: string } | null }):
           </div>
         </div>
       </div>
+
+      <!-- Connection line from API down to Terminology row -->
+      <div class="flex items-center gap-3">
+        <div class="min-w-[140px]" />
+        <span class="invisible">&rarr;</span>
+        <div class="min-w-[140px] flex justify-center">
+          <span class="text-muted-foreground">&darr;</span>
+        </div>
+      </div>
+
+      <!-- Row 3: Terminology Server -->
+      <div class="flex items-center gap-3">
+        <div class="min-w-[140px]" />
+        <span class="invisible">&rarr;</span>
+        <div class="flex items-center gap-2 rounded-md border px-4 py-3 min-w-[140px]">
+          <span class="h-2.5 w-2.5 rounded-full shrink-0" :class="terminologyStatusColor(terminology.status)" />
+          <div>
+            <p class="text-sm font-medium">Terminology</p>
+            <p class="text-xs text-muted-foreground">{{ terminologyLabel(terminology) }}</p>
+          </div>
+        </div>
+        <span class="text-muted-foreground text-xs">&larr;</span>
+        <div class="text-xs text-muted-foreground">
+          <p>{{ terminologyHostname(terminology) }}</p>
+          <p v-if="terminology.data?.response_ms != null">{{ terminology.data.response_ms }}ms</p>
+        </div>
+      </div>
     </div>
 
     <!-- Mobile: stacked cards -->
@@ -91,6 +144,7 @@ function statusLabel(item: { status: string; data: { status: string } | null }):
           { name: 'App Database', status: healthChecks.data.database.status, desc: 'PostgreSQL', label: statusLabel(healthChecks.data.database) },
           { name: 'EHRBase', status: healthChecks.data.ehrbase.status, desc: 'openEHR CDR', label: statusLabel(healthChecks.data.ehrbase) },
           { name: 'EHRBase DB', status: healthChecks.data.ehrbase.status, desc: 'PostgreSQL', label: statusLabel(healthChecks.data.ehrbase) },
+          { name: 'Terminology', status: terminology.status === 'ok' ? 'ok' as const : 'error' as const, desc: terminologyHostname(terminology), label: terminologyLabel(terminology) },
         ]"
         :key="item.name"
         class="flex items-center gap-2 rounded-md border px-4 py-3"

--- a/web/src/pages/SystemInfoPage.vue
+++ b/web/src/pages/SystemInfoPage.vue
@@ -69,7 +69,10 @@ onUnmounted(() => {
 
     <template v-if="store.systemInfo">
       <!-- Health Diagram -->
-      <SystemHealthDiagram :health-checks="store.systemInfo.healthChecks" />
+      <SystemHealthDiagram
+        :health-checks="store.systemInfo.healthChecks"
+        :terminology="store.systemInfo.terminology"
+      />
 
       <!-- Version Info + Data Stats -->
       <div class="grid gap-6 md:grid-cols-2">
@@ -93,6 +96,18 @@ onUnmounted(() => {
           <p v-else class="text-sm text-muted-foreground">
             {{ store.systemInfo.version.error?.message ?? 'Could not determine versions' }}
           </p>
+          <!-- Terminology Server Info -->
+          <div v-if="store.systemInfo.terminology.data" class="border-t pt-3 mt-3 space-y-2">
+            <h3 class="text-sm font-medium">Terminology Server</h3>
+            <div class="flex justify-between text-sm">
+              <span class="text-muted-foreground">URL</span>
+              <span class="font-mono text-xs truncate max-w-[200px]">{{ store.systemInfo.terminology.data.url }}</span>
+            </div>
+            <div v-if="store.systemInfo.terminology.data.response_ms != null" class="flex justify-between text-sm">
+              <span class="text-muted-foreground">Response</span>
+              <span class="font-mono">{{ store.systemInfo.terminology.data.response_ms }}ms</span>
+            </div>
+          </div>
         </div>
 
         <!-- Data Stats -->

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -96,6 +96,7 @@ export interface HealthChecksData {
   api: HealthCheckItem
   database: HealthCheckItem
   ehrbase: HealthCheckItem
+  terminology: HealthCheckItem
 }
 
 export interface HealthChecksSection {
@@ -140,11 +141,23 @@ export interface DbCountsSection {
   error: SectionError | null
 }
 
+export interface TerminologyData {
+  url: string
+  response_ms: number | null
+}
+
+export interface TerminologySection {
+  status: 'ok' | 'partial' | 'error'
+  data: TerminologyData | null
+  error: SectionError | null
+}
+
 export interface SystemInfo {
   healthChecks: HealthChecksSection
   version: VersionSection
   templates: TemplatesSection
   dbCounts: DbCountsSection
+  terminology: TerminologySection
 }
 
 // Re-export vitals types


### PR DESCRIPTION
## Summary

Integrate a FHIR-compatible terminology server into Open CIS to enable human-readable display of coded clinical values stored in openEHR compositions. This implementation provides a lightweight async client backed by the Swiss public FHIR terminology server (`tx.fhir.ch`) with support for swapping to self-hosted instances via environment configuration.

## Key Changes

### Core Terminology Infrastructure
- **`TerminologyClient`** (`api/src/terminology/client.py`): Async FHIR R4 client using httpx with in-memory TTL caching for `$lookup`, `$validate-code`, and `$expand` operations. All operations fail softly to prevent terminology server outages from blocking composition reads.
- **System mapping** (`api/src/terminology/systems.py`): Bidirectional mapping between openEHR terminology identifiers (e.g., `SNOMED-CT`, `LOINC`) and FHIR canonical URIs, with special handling for internal terminologies (`openehr`, `local`).
- **Composition enrichment** (`api/src/terminology/enrichment.py`): Post-processing functions that walk openEHR composition JSON trees and resolve `DV_CODED_TEXT` display terms via concurrent batch lookups. Supports both STRUCTURED and FLAT composition formats.

### API Endpoints
- **Terminology router** (`api/src/terminology/router.py`): 
  - `GET /api/terminology/health` — health check for upstream terminology server
  - `GET /api/fhir/CodeSystem/$lookup` — code lookup pass-through
  - `GET /api/fhir/ValueSet/$expand` — ValueSet expansion for medblocks-ui components
- **System info integration**: Extended `GET /api/system/info` to include terminology server health status in the system health checks section.

### Configuration & Lifecycle
- **Settings** (`api/src/config.py`): New configuration options for terminology server URL, cache TTL, timeout, and enable/disable flag. Defaults to Swiss public server with no authentication required.
- **Singleton client** (`api/src/main.py`): Global `terminology_client` instance initialized on app startup and gracefully closed on shutdown.
- **Environment variables** (`.env.example`): Added `TERMINOLOGY_SERVER_URL`, `TERMINOLOGY_ENABLED`, `TERMINOLOGY_CACHE_TTL_SECONDS`, and `TERMINOLOGY_TIMEOUT_SECONDS`.

### Frontend Integration
- **System health diagram** (`web/src/components/system/SystemHealthDiagram.vue`): Visual representation of terminology server connectivity status alongside EHRBase and database health.
- **Type definitions** (`web/src/types/index.ts`): Added `TerminologySection` and `TerminologyData` types for system info responses.
- **System info page** (`web/src/pages/SystemInfoPage.vue`): Display terminology server status and configuration.

### Testing
- **Comprehensive unit tests** (`api/tests/unit/test_terminology.py`): 421 lines covering system mapping, client operations (lookup, validate-code, expand, health check), caching behavior, error handling, and composition enrichment for both STRUCTURED and FLAT formats.
- **Test fixtures** (`api/tests/unit/conftest.py`): Async test setup without database dependencies.

## Implementation Details

- **Lazy enrichment pattern**: Composition enrichment happens in API response handlers (not in CDR write path), consistent with the project's lazy resolution principle.
- **Concurrent batch resolution**: Uses `asyncio.gather()` to resolve multiple codes in parallel, with deduplication to minimize upstream calls.
- **Soft failures**: Network errors, timeouts, and 404 responses return `None`/`False` rather than raising exceptions, ensuring terminology server unavailability never blocks clinical workflows.
- **In-memory caching**: `cachetools.TTLCache` with configurable TTL (default 1 hour) eliminates redundant lookups without requiring Redis.
- **Configuration flexibility**: Swapping from Swiss public server to self-hosted Snowstorm Lite requires only an environment variable change; no code modifications needed.

## Dependencies Added
- `cachetools>=5.3.0

https://claude.ai/code/session_019Q9pnonnFFNxRYFcjU6A7n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated FHIR Terminology Server integration to resolve coded values into human-readable display names
  * Enhanced composition responses with terminology enrichment for coded terms
  * Added terminology server health check endpoint
  * Exposed code lookup and validation API endpoints for terminology operations
  * Updated system health dashboard to display terminology server connectivity status

* **Documentation**
  * Added FHIR Terminology integration specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->