### PR TITLE
fix: fix EHRBase status endpoint parsing from XML response

### DIFF
--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.metadata
 import logging
+import xml.etree.ElementTree as ET
 from typing import Any
 
 from src.config import settings
@@ -243,13 +244,15 @@ class SystemService:
         except Exception:
             return result
 
-        # Fetch version from EHRBase status endpoint
+        # Fetch version from EHRBase status endpoint (returns XML)
         try:
             client = await ehrbase_client._ensure_connected()
             response = await client.client.get("/rest/status")
             if response.status_code == 200:
-                data = response.json()
-                result["version"] = data.get("version", "unknown")
+                root = ET.fromstring(response.text)
+                version_el = root.find("ehrbase_version")
+                if version_el is not None and version_el.text:
+                    result["version"] = version_el.text
         except Exception as e:
             logger.debug("Could not fetch EHRBase version: %s", e)
 


### PR DESCRIPTION
## Summary
Updated the EHRBase status endpoint response parsing to handle XML format instead of JSON, aligning with the actual API response format.

## Key Changes
- Added `xml.etree.ElementTree` import for XML parsing
- Changed response parsing from `response.json()` to `ET.fromstring(response.text)` to handle XML response body
- Updated version extraction to use XML element lookup (`root.find("ehrbase_version")`) instead of dictionary access
- Added null check for the version element before accessing its text content

## Implementation Details
- The EHRBase `/rest/status` endpoint returns XML, not JSON as previously assumed
- The version information is now extracted from the `ehrbase_version` XML element
- Error handling remains in place with debug logging for any parsing failures

https://claude.ai/code/session_01Y42PUZrWeiWibXHJEdJTGw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed EHRBase integration to correctly retrieve version information from system responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->