### PR TITLE
fix: Add EHRBase v2 JSON support with v1 XML fallback

### DIFF
--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -245,24 +245,34 @@ class SystemService:
         except Exception:
             return result
 
-        # Fetch version from EHRBase status endpoint
-        # EHRBase v2 returns JSON with camelCase fields by default;
-        # fall back to XML parsing for v1 compatibility.
+        # Fetch version from EHRBase /rest/status endpoint.
+        # The response may be XML (default) or JSON depending on the Accept
+        # header the HTTP client sends.  We try both formats to be safe.
         try:
             client = await ehrbase_client._ensure_connected()
             response = await client.client.get("/rest/status")
             if response.status_code == 200:
+                content_type = response.headers.get("content-type", "")
                 text = response.text.strip()
-                # Try JSON first (EHRBase v2 default)
-                try:
-                    data = json.loads(text)
-                    version = data.get("ehrbaseVersion") or data.get("ehrbase_version")
-                    if version:
-                        result["version"] = version
-                except (json.JSONDecodeError, AttributeError):
-                    pass
-                # Fall back to XML (EHRBase v1)
-                if result["version"] is None and text.startswith("<"):
+                logger.debug(
+                    "EHRBase /rest/status content-type=%s body=%s",
+                    content_type,
+                    text[:500],
+                )
+                # Try JSON (oehrpy client may request application/json)
+                if "json" in content_type or text.startswith("{"):
+                    try:
+                        data = json.loads(text)
+                        version = (
+                            data.get("ehrbaseVersion")
+                            or data.get("ehrbase_version")
+                        )
+                        if version:
+                            result["version"] = version
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+                # Try XML (EHRBase default Content-Type: application/xml)
+                if result["version"] is None and ("xml" in content_type or text.startswith("<")):
                     try:
                         root = ET.fromstring(text)
                         version_el = root.find("ehrbase_version")
@@ -270,6 +280,13 @@ class SystemService:
                             result["version"] = version_el.text
                     except ET.ParseError:
                         pass
+                if result["version"] is None:
+                    logger.warning(
+                        "EHRBase /rest/status returned 200 but version could not "
+                        "be parsed. content-type=%s body=%s",
+                        content_type,
+                        text[:500],
+                    )
         except Exception as e:
             logger.debug("Could not fetch EHRBase version: %s", e)
 

--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.metadata
+import json
 import logging
 import xml.etree.ElementTree as ET
 from typing import Any
@@ -244,15 +245,31 @@ class SystemService:
         except Exception:
             return result
 
-        # Fetch version from EHRBase status endpoint (returns XML)
+        # Fetch version from EHRBase status endpoint
+        # EHRBase v2 returns JSON with camelCase fields by default;
+        # fall back to XML parsing for v1 compatibility.
         try:
             client = await ehrbase_client._ensure_connected()
             response = await client.client.get("/rest/status")
             if response.status_code == 200:
-                root = ET.fromstring(response.text)
-                version_el = root.find("ehrbase_version")
-                if version_el is not None and version_el.text:
-                    result["version"] = version_el.text
+                text = response.text.strip()
+                # Try JSON first (EHRBase v2 default)
+                try:
+                    data = json.loads(text)
+                    version = data.get("ehrbaseVersion") or data.get("ehrbase_version")
+                    if version:
+                        result["version"] = version
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+                # Fall back to XML (EHRBase v1)
+                if result["version"] is None and text.startswith("<"):
+                    try:
+                        root = ET.fromstring(text)
+                        version_el = root.find("ehrbase_version")
+                        if version_el is not None and version_el.text:
+                            result["version"] = version_el.text
+                    except ET.ParseError:
+                        pass
         except Exception as e:
             logger.debug("Could not fetch EHRBase version: %s", e)
 

--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -252,7 +252,7 @@ class SystemService:
             client = await ehrbase_client._ensure_connected()
             response = await client.client.get("/rest/status")
             if response.status_code == 200:
-                content_type = response.headers.get("content-type", "")
+                content_type = response.headers.get("content-type", "").lower()
                 text = response.text.strip()
                 logger.debug(
                     "EHRBase /rest/status content-type=%s body=%s",


### PR DESCRIPTION
## Summary
Updated the EHRBase status endpoint parsing to support both EHRBase v2 (JSON response) and v1 (XML response) formats, with intelligent fallback logic.

## Key Changes
- Added JSON parsing as the primary method for fetching EHRBase version, supporting both camelCase (`ehrbaseVersion`) and snake_case (`ehrbase_version`) field names used by v2
- Implemented fallback to XML parsing for backward compatibility with EHRBase v1
- Added response text validation to detect format type before parsing
- Improved error handling with graceful degradation for both JSON and XML parsing failures
- Added clarifying comments explaining the version-specific response formats

## Implementation Details
- JSON parsing is attempted first since EHRBase v2 returns JSON by default
- The parser checks for both `ehrbaseVersion` (camelCase) and `ehrbase_version` (snake_case) keys to handle potential variations
- XML fallback only triggers if JSON parsing fails and the response starts with `<` character
- All parsing exceptions are caught and logged at debug level, allowing the service to continue even if version detection fails
- The version field is only set if a valid version string is found, maintaining the existing behavior

https://claude.ai/code/session_01QWSd7UoiiACv5HxqKaXUpg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System status/version detection improved to handle both JSON and XML responses from external services. Parsing now attempts JSON first, falls back to XML, logs response details for diagnostics, and warns if a 200 response cannot be parsed—making version detection more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->