### PR TITLE
feat(api): compare templates before uploading to avoid 409/500 errors

### DIFF
--- a/api/src/ehrbase/client.py
+++ b/api/src/ehrbase/client.py
@@ -246,6 +246,48 @@ class EHRBaseClient:
             ) from e
         return {"template_id": result.template_id, "status": "uploaded"}
 
+    async def get_template_opt(self, template_id: str) -> str | None:
+        """Fetch the raw OPT XML for a template from EHRBase.
+
+        Returns the OPT XML string, or None if not found.
+        """
+        client = await self._ensure_connected()
+        try:
+            response = await client.client.get(
+                f"/rest/openehr/v1/definition/template/adl1.4/{template_id}",
+                headers={"Accept": "application/xml"},
+            )
+            if response.status_code == 200:
+                return response.text
+            return None
+        except (httpx.RequestError, OSError) as e:
+            raise EHRBaseUnavailableError(
+                message="Cannot connect to EHRBase. Is it running?"
+            ) from e
+
+    async def update_template_opt(
+        self, template_id: str, template_content: str
+    ) -> bool:
+        """Update an existing OPT template in EHRBase via PUT.
+
+        Returns True if the update succeeded, False otherwise.
+        """
+        client = await self._ensure_connected()
+        try:
+            response = await client.client.put(
+                f"/rest/openehr/v1/definition/template/adl1.4/{template_id}",
+                content=template_content,
+                headers={"Content-Type": "application/xml"},
+            )
+            return response.status_code in (200, 204)
+        except EHRBaseError as e:
+            logger.error("EHRBase update template error: %s", e)
+            return False
+        except (httpx.RequestError, OSError) as e:
+            raise EHRBaseUnavailableError(
+                message="Cannot connect to EHRBase. Is it running?"
+            ) from e
+
     async def get_template_example(
         self, template_id: str, format: str = "FLAT"
     ) -> dict[str, Any]:

--- a/api/src/ehrbase/templates.py
+++ b/api/src/ehrbase/templates.py
@@ -1,6 +1,8 @@
 """Template management for EHRBase."""
 
+import hashlib
 import logging
+import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +13,21 @@ from openehr_sdk.client import EHRBaseError
 from src.ehrbase.client import ehrbase_client
 
 logger = logging.getLogger(__name__)
+
+
+def _xml_hash(xml_content: str) -> str:
+    """Compute a hash of XML content using C14N (canonical XML) for deterministic comparison.
+
+    This normalises whitespace, attribute order, and namespace declarations
+    so that semantically identical documents produce the same hash, even if
+    their raw text differs.
+    """
+    try:
+        canonical = ET.canonicalize(xml_data=xml_content)
+        return hashlib.sha256(canonical.encode()).hexdigest()
+    except ET.ParseError:
+        # Fallback: hash the stripped raw text if XML parsing fails
+        return hashlib.sha256(xml_content.strip().encode()).hexdigest()
 
 # Web template cache status, populated by warm_web_template_cache()
 _web_template_cache_status: dict[str, bool] = {}
@@ -68,11 +85,57 @@ async def upload_template_file(template_id: str, template_content: str) -> bool:
         return False
 
 
+async def _sync_template(template_id: str, local_content: str) -> bool:
+    """Sync a single template: skip if unchanged, update or upload as needed.
+
+    Returns True if the template is now in sync, False on failure.
+    """
+    # Try to fetch the currently registered OPT from EHRBase
+    try:
+        remote_opt = await ehrbase_client.get_template_opt(template_id)
+    except Exception as e:
+        logger.warning(f"Could not fetch existing OPT for {template_id}: {e}")
+        remote_opt = None
+
+    if remote_opt is not None:
+        # Template exists in EHRBase — compare with local version
+        local_hash = _xml_hash(local_content)
+        remote_hash = _xml_hash(remote_opt)
+
+        if local_hash == remote_hash:
+            logger.info(f"Template {template_id} is up to date")
+            return True
+
+        # Template has changed — attempt to update via PUT
+        logger.info(f"Template {template_id} has changed, updating...")
+        try:
+            updated = await ehrbase_client.update_template_opt(template_id, local_content)
+            if updated:
+                logger.info(f"Template {template_id} updated successfully")
+                return True
+            logger.warning(
+                f"EHRBase rejected PUT update for {template_id}, "
+                "template may be in use by existing compositions"
+            )
+            return False
+        except Exception as e:
+            logger.warning(f"Could not update template {template_id}: {e}")
+            return False
+    else:
+        # Template not yet registered — upload it
+        return await upload_template_file(template_id, local_content)
+
+
 async def ensure_templates_registered() -> dict[str, bool]:
     """
     Ensure all required templates are registered in EHRBase.
 
-    Called during API startup. Returns a dict mapping template_id to success status.
+    Called during API startup. For each template:
+    - If not registered: uploads it.
+    - If registered and unchanged: skips it.
+    - If registered and changed: attempts to update via PUT.
+
+    Returns a dict mapping template_id to success status.
     """
     results: dict[str, bool] = {}
 
@@ -97,7 +160,6 @@ async def ensure_templates_registered() -> dict[str, bool]:
         logger.warning(f"Could not connect to EHRBase to check templates: {e}")
         return results
 
-    # Upload all required templates (always re-upload to keep in sync)
     for template_id in REQUIRED_TEMPLATES:
         template_file = templates_dir / f"{template_id}.opt"
 
@@ -106,14 +168,10 @@ async def ensure_templates_registered() -> dict[str, bool]:
             results[template_id] = False
             continue
 
-        # Always upload to ensure the template matches the repo version.
-        # EHRBase returns 409 if the template already exists and is identical,
-        # which upload_template_file handles gracefully.
-        logger.info(f"Uploading template {template_id}...")
         try:
             async with aiofiles.open(template_file, encoding="utf-8") as f:
-                template_content = await f.read()
-            results[template_id] = await upload_template_file(template_id, template_content)
+                local_content = await f.read()
+            results[template_id] = await _sync_template(template_id, local_content)
         except Exception as e:
             logger.error(f"Failed to read template file {template_file}: {e}")
             results[template_id] = False

--- a/api/tests/unit/test_template_sync.py
+++ b/api/tests/unit/test_template_sync.py
@@ -1,0 +1,146 @@
+"""Tests for template change detection and sync logic."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.ehrbase.templates import _sync_template, _xml_hash
+
+# ---------------------------------------------------------------------------
+# _xml_hash — canonical XML hashing
+# ---------------------------------------------------------------------------
+
+
+class TestXmlHash:
+    """Test the _xml_hash helper that normalises XML before hashing."""
+
+    def test_identical_xml_produces_same_hash(self):
+        xml = "<root><child attr='1'>text</child></root>"
+        assert _xml_hash(xml) == _xml_hash(xml)
+
+    def test_different_xml_produces_different_hash(self):
+        xml_a = "<root><a>1</a></root>"
+        xml_b = "<root><a>2</a></root>"
+        assert _xml_hash(xml_a) != _xml_hash(xml_b)
+
+    def test_empty_element_syntax_is_normalised(self):
+        """C14N normalises <br/> vs <br></br> — both produce the same hash."""
+        self_closing = "<root><child/></root>"
+        expanded = "<root><child></child></root>"
+        assert _xml_hash(self_closing) == _xml_hash(expanded)
+
+    def test_attribute_order_is_normalised(self):
+        xml_a = '<root a="1" b="2"/>'
+        xml_b = '<root b="2" a="1"/>'
+        assert _xml_hash(xml_a) == _xml_hash(xml_b)
+
+    def test_invalid_xml_falls_back_to_raw_hash(self):
+        bad = "not xml at all <<<"
+        # Should not raise, and should return a deterministic hash
+        h = _xml_hash(bad)
+        assert isinstance(h, str)
+        assert len(h) == 64  # SHA-256 hex digest length
+        assert _xml_hash(bad) == h
+
+    def test_empty_string_does_not_raise(self):
+        h = _xml_hash("")
+        assert isinstance(h, str)
+
+
+# ---------------------------------------------------------------------------
+# _sync_template — skip / upload / update logic
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_OPT = "<template><id>Test.v1</id></template>"
+MODIFIED_OPT = "<template><id>Test.v1</id><extra/></template>"
+
+
+class TestSyncTemplateSkipsUnchanged:
+    """When the remote OPT matches the local file, no upload should happen."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_template_returns_true(self):
+        with patch("src.ehrbase.templates.ehrbase_client") as mock_client:
+            mock_client.get_template_opt = AsyncMock(return_value=SAMPLE_OPT)
+            mock_client.update_template_opt = AsyncMock()
+            mock_client.upload_template = AsyncMock()
+
+            result = await _sync_template("Test.v1", SAMPLE_OPT)
+
+            assert result is True
+            mock_client.update_template_opt.assert_not_called()
+            mock_client.upload_template.assert_not_called()
+
+
+class TestSyncTemplateUploadsNew:
+    """When the template is not in EHRBase, it should be uploaded."""
+
+    @pytest.mark.asyncio
+    async def test_new_template_is_uploaded(self):
+        with patch("src.ehrbase.templates.ehrbase_client") as mock_client:
+            mock_client.get_template_opt = AsyncMock(return_value=None)
+            mock_client.upload_template = AsyncMock(
+                return_value={"template_id": "Test.v1", "status": "uploaded"}
+            )
+
+            result = await _sync_template("Test.v1", SAMPLE_OPT)
+
+            assert result is True
+            mock_client.upload_template.assert_called_once()
+
+
+class TestSyncTemplateUpdatesChanged:
+    """When the remote OPT differs, a PUT update should be attempted."""
+
+    @pytest.mark.asyncio
+    async def test_changed_template_triggers_put_update(self):
+        with patch("src.ehrbase.templates.ehrbase_client") as mock_client:
+            mock_client.get_template_opt = AsyncMock(return_value=MODIFIED_OPT)
+            mock_client.update_template_opt = AsyncMock(return_value=True)
+
+            result = await _sync_template("Test.v1", SAMPLE_OPT)
+
+            assert result is True
+            mock_client.update_template_opt.assert_called_once_with("Test.v1", SAMPLE_OPT)
+
+    @pytest.mark.asyncio
+    async def test_put_update_rejected_returns_false(self):
+        with patch("src.ehrbase.templates.ehrbase_client") as mock_client:
+            mock_client.get_template_opt = AsyncMock(return_value=MODIFIED_OPT)
+            mock_client.update_template_opt = AsyncMock(return_value=False)
+
+            result = await _sync_template("Test.v1", SAMPLE_OPT)
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_put_update_exception_returns_false(self):
+        with patch("src.ehrbase.templates.ehrbase_client") as mock_client:
+            mock_client.get_template_opt = AsyncMock(return_value=MODIFIED_OPT)
+            mock_client.update_template_opt = AsyncMock(
+                side_effect=Exception("EHRBase unavailable")
+            )
+
+            result = await _sync_template("Test.v1", SAMPLE_OPT)
+
+            assert result is False
+
+
+class TestSyncTemplateFetchFailure:
+    """When fetching the remote OPT fails, fall back to upload."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_falls_back_to_upload(self):
+        with patch("src.ehrbase.templates.ehrbase_client") as mock_client:
+            mock_client.get_template_opt = AsyncMock(
+                side_effect=Exception("Connection refused")
+            )
+            mock_client.upload_template = AsyncMock(
+                return_value={"template_id": "Test.v1", "status": "uploaded"}
+            )
+
+            result = await _sync_template("Test.v1", SAMPLE_OPT)
+
+            assert result is True
+            mock_client.upload_template.assert_called_once()

--- a/docs/adr/0010-template-change-detection.md
+++ b/docs/adr/0010-template-change-detection.md
@@ -1,0 +1,181 @@
+# 10. Template Change Detection on Startup
+
+Date: 2026-04-10
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0003 established that Open CIS automatically uploads required Operational
+Templates (OPT) to EHRBase on API startup. The original implementation always
+attempted to POST every template, relying on EHRBase's 409 Conflict response
+to signal that the template already existed.
+
+This caused two problems in practice:
+
+1. **Noisy error logs.** Every startup produced 409 errors for every template
+   that was already registered. While these were handled gracefully (treated as
+   success), they cluttered logs and made it harder to spot real failures. On
+   Railway staging, the log output looked like:
+
+   ```
+   ERROR: EHRBase error: Request failed: 409 - {"error":"Conflict",
+          "message":"Operational template with this template ID already exists: ..."}
+   ```
+
+2. **Unpredictable 500 errors.** Some EHRBase versions (notably v2.x with
+   certain PostgreSQL configurations) respond with 500 Internal Server Error
+   instead of 409 when a duplicate template is uploaded. This caused startup
+   warnings that suggested a real failure, even though the template was
+   correctly registered.
+
+3. **No update path.** If a template was modified locally (e.g., a new
+   archetype constraint or a bugfix in the OPT), the only way to propagate
+   the change was to manually delete the template from EHRBase and restart the
+   API — or redeploy with a clean EHRBase database. There was no mechanism to
+   detect that the local OPT differed from the registered one.
+
+### Constraints
+
+- EHRBase's `POST /rest/openehr/v1/definition/template/adl1.4` rejects
+  duplicates (409 or 500 depending on version); it does not upsert.
+- EHRBase v2 supports `PUT /rest/openehr/v1/definition/template/adl1.4/{id}`
+  for updating an existing template, but the update may be rejected if existing
+  compositions reference the template and the change is not backwards-compatible.
+- EHRBase returns the stored OPT XML via
+  `GET /rest/openehr/v1/definition/template/adl1.4/{id}` with
+  `Accept: application/xml`, but it may reformat the XML (attribute order,
+  namespace declarations, empty element syntax) compared to the original file.
+- The oehrpy SDK (v0.7.0) does not provide `get_template_opt()`,
+  `update_template()`, or `delete_template()` methods (documented as P0 gaps
+  in PRD-0010).
+
+## Decision
+
+We implement a **compare-before-upload** strategy using canonical XML hashing.
+On startup, for each required template:
+
+1. **Fetch** the existing OPT XML from EHRBase via a direct HTTP GET
+   (`GET /rest/openehr/v1/definition/template/adl1.4/{template_id}` with
+   `Accept: application/xml`).
+2. **Hash** both the local and remote OPT using XML Canonical Form (C14N) via
+   Python's `xml.etree.ElementTree.canonicalize()`, then SHA-256. C14N
+   normalises attribute order, namespace declarations, and empty element syntax
+   so that semantically identical documents produce the same hash.
+3. **Compare** hashes:
+   - **Match** — template is up to date; skip upload entirely.
+   - **Mismatch** — template has changed; attempt a `PUT` update.
+   - **No remote OPT** (template not registered or fetch failed) — `POST` upload
+     as before.
+
+### New client methods
+
+Two methods are added to `EHRBaseClient` in `api/src/ehrbase/client.py`, using
+direct HTTP calls to the oehrpy SDK's underlying httpx client (same pattern as
+the existing `get_web_template()` and `delete_composition()` methods):
+
+- `get_template_opt(template_id) -> str | None` — fetches the raw OPT XML.
+- `update_template_opt(template_id, content) -> bool` — PUTs an updated OPT.
+
+### Sync logic
+
+A new `_sync_template()` function in `api/src/ehrbase/templates.py` encapsulates
+the compare-and-act logic. `ensure_templates_registered()` delegates to it
+instead of unconditionally calling `upload_template_file()`.
+
+### Fallback on C14N failure
+
+If `ET.canonicalize()` raises `ParseError` (e.g., EHRBase returns non-XML
+content), the hash function falls back to a SHA-256 of the stripped raw text.
+This is a safe fallback: in the worst case it produces a false mismatch,
+triggering an unnecessary PUT update — which is the safe direction.
+
+## Alternatives Considered
+
+### Keep the unconditional POST approach
+
+Continue uploading every template on startup and suppress 409 errors.
+
+**Rejected.** This is the status quo. It produces noisy logs, masks real 500
+errors, and provides no update path when templates change.
+
+### Compare raw XML strings
+
+Hash the raw bytes of the local file and the EHRBase response without
+canonicalisation.
+
+**Rejected.** EHRBase may reformat XML on storage (e.g., reorder attributes,
+expand self-closing tags). Raw comparison would produce false mismatches,
+triggering unnecessary PUT updates on every startup.
+
+### Store a local hash/checksum file
+
+Maintain a `.template-checksums` file alongside the OPT files, recording the
+hash of the last successfully uploaded version.
+
+**Rejected.** This adds state that can drift from reality (e.g., after a manual
+EHRBase database reset). Comparing directly with EHRBase is the single source
+of truth.
+
+### Delete and re-upload on mismatch
+
+Instead of PUT, use `DELETE` then `POST` when a template has changed.
+
+**Rejected.** EHRBase may refuse to delete a template that has existing
+compositions. The PUT approach is safer because EHRBase can validate backwards
+compatibility before accepting the update. DELETE+POST also creates a window
+where the template is unregistered, which could cause failures if requests
+arrive concurrently during startup.
+
+## Consequences
+
+### Positive
+
+- **Clean logs.** Unchanged templates produce a single `INFO: Template X is up
+  to date` line instead of error-level 409/500 messages.
+- **Automatic updates.** When a developer modifies an OPT file and deploys, the
+  change is detected and applied via PUT without manual intervention.
+- **Correct error reporting.** Real failures (EHRBase down, template rejected)
+  are clearly distinguishable from the "already exists" noise.
+- **No extra state.** The comparison uses EHRBase as the source of truth, with
+  no local checksum files to maintain.
+
+### Negative
+
+- **Extra HTTP call per template.** Each startup now makes a GET request per
+  template to fetch the existing OPT. For the current 2 templates this adds
+  negligible latency (<100ms total).
+- **PUT may be rejected.** If EHRBase cannot update a template because existing
+  compositions would become invalid, the update fails and a warning is logged.
+  Manual intervention (database reset or compatible template change) is required
+  in this case. This is an EHRBase constraint, not a limitation of this
+  approach.
+- **C14N is not perfect.** If EHRBase introduces changes to the OPT that C14N
+  does not normalise (e.g., adding server-generated comments), false mismatches
+  will occur. The consequence is an unnecessary PUT attempt, which is harmless.
+
+### Neutral
+
+- The existing `upload_template_file()` function is retained for the "new
+  template" code path and is unchanged.
+- The startup sequence in `main.py` is unchanged — `ensure_templates_registered()`
+  is still called first, followed by `warm_web_template_cache()`.
+
+## File Locations
+
+```
+api/src/ehrbase/
+├── client.py          # + get_template_opt(), update_template_opt()
+└── templates.py       # + _xml_hash(), _sync_template(); updated ensure_templates_registered()
+
+api/tests/unit/
+└── test_template_sync.py   # Unit tests for hash and sync logic
+```
+
+## Related
+
+- [ADR-0003: openEHR Template Management](./0003-openehr-template-management.md) — original template upload decision
+- [ADR-0009: oehrpy Web Template Integration](./0009-oehrpy-web-template-integration.md) — Web Template caching on startup
+- `docs/prd/0010-oehrpy-coverage-gaps.md` — documents missing `delete_template` / `update_template` in oehrpy SDK


### PR DESCRIPTION
Instead of always re-uploading templates on startup (which causes 409 Conflict when unchanged and 500 errors on some EHRBase versions), fetch the existing OPT XML from EHRBase and compare using C14N canonical XML hashing. Only upload new templates or PUT-update changed ones.

https://claude.ai/code/session_01VcRCT7oGV8g5uf3AixL8f7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API can retrieve and update operational templates remotely.
  * Startup now syncs templates intelligently: compares local vs remote and skips unchanged templates, updates changed ones, or uploads missing templates.
* **Tests**
  * Added unit tests for XML hash/canonicalization and template sync behaviors.
* **Documentation**
  * New ADR describing the template change-detection and sync strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->