### PR TITLE
chore: add oehrpy SDK version to system info

### DIFF
--- a/api/src/system/schemas.py
+++ b/api/src/system/schemas.py
@@ -42,6 +42,7 @@ class TemplateInfo(BaseModel):
 class VersionData(BaseModel):
     api: str = Field(..., description="Open CIS API version")
     ehrbase: str | None = Field(None, description="EHRBase version (null if unavailable)")
+    oehrpy: str | None = Field(None, description="oehrpy SDK version (null if unavailable)")
 
 
 class DbCountsData(BaseModel):

--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -171,7 +171,12 @@ class SystemService:
         if not isinstance(ehrbase_result, BaseException):
             ehrbase_version = ehrbase_result.get("version")
 
-        data = VersionData(api=api_version, ehrbase=ehrbase_version)
+        try:
+            oehrpy_version: str | None = importlib.metadata.version("oehrpy")
+        except importlib.metadata.PackageNotFoundError:
+            oehrpy_version = None
+
+        data = VersionData(api=api_version, ehrbase=ehrbase_version, oehrpy=oehrpy_version)
 
         if ehrbase_version is not None:
             return VersionSection(status="ok", data=data, error=None)

--- a/web/src/pages/SystemInfoPage.vue
+++ b/web/src/pages/SystemInfoPage.vue
@@ -92,6 +92,10 @@ onUnmounted(() => {
               <span class="text-muted-foreground">Frontend</span>
               <span class="font-mono">{{ frontendVersion }}</span>
             </div>
+            <div class="flex justify-between text-sm">
+              <a href="https://platzhersh.github.io/oehrpy/" target="_blank" rel="noopener noreferrer" class="text-muted-foreground hover:text-foreground transition-colors hover:underline">oehrpy</a>
+              <span class="font-mono">{{ store.systemInfo.version.data.oehrpy ?? 'N/A' }}</span>
+            </div>
           </div>
           <p v-else class="text-sm text-muted-foreground">
             {{ store.systemInfo.version.error?.message ?? 'Could not determine versions' }}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -108,6 +108,7 @@ export interface HealthChecksSection {
 export interface VersionData {
   api: string
   ehrbase: string | null
+  oehrpy: string | null
 }
 
 export interface VersionSection {


### PR DESCRIPTION
## Summary
This PR adds the oehrpy SDK version to the system information endpoint and displays it in the System Info page UI.

## Key Changes
- **Backend (api/src/system/):**
  - Updated `VersionData` schema to include an optional `oehrpy` field for the SDK version
  - Modified `_build_version()` method to detect and include the oehrpy package version using `importlib.metadata`
  - Gracefully handles cases where the package is not found by setting the version to `None`

- **Frontend (web/src/):**
  - Updated TypeScript `VersionData` interface to include the `oehrpy` field
  - Added a new row in the System Info page to display the oehrpy version with a link to the official documentation
  - Displays "N/A" when the version is unavailable

## Implementation Details
- The oehrpy version is retrieved using `importlib.metadata.version()` with proper exception handling for `PackageNotFoundError`
- The frontend link points to the official oehrpy documentation at `https://platzhersh.github.io/oehrpy/`
- The UI follows the existing design pattern with consistent styling and hover effects

https://claude.ai/code/session_0136vs5Xzy7bZM3hoJmMHqDD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * System information page now displays the installed oehrpy SDK version alongside existing version information (API, EHRBase, and Frontend versions). Shows "N/A" when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->