### PR TITLE
Configure Vite build-time environment variables in Docker

### DIFF
--- a/dex/README.md
+++ b/dex/README.md
@@ -43,10 +43,13 @@ On the **dex** service, set:
 
 | Variable | Example value |
 |---|---|
+| `DEX_EXPAND_ENV` | `true` |
 | `DEX_ISSUER` | `https://dex-open-cis.up.railway.app/dex` |
 | `DEX_REDIRECT_URI` | `https://open-cis-web.up.railway.app/auth/callback` |
 | `DEX_DEMO_ADMIN_HASH` | *(see below)* |
 | `DEX_DEMO_CLINICIAN_HASH` | *(see below)* |
+
+> **Important:** `DEX_EXPAND_ENV=true` is required for Dex to substitute `${VAR}` placeholders in `config.railway.yaml`. Without it, Dex reads the config literally and you'll get errors like `malformed bcrypt hash: hashedSecret too short` (because the literal string `${DEX_DEMO_ADMIN_HASH}` is too short to be a valid bcrypt hash).
 
 `DEX_ISSUER` **must** match the public URL of the Dex service exactly (including `/dex` path).
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -14,6 +14,17 @@ RUN pnpm install --frozen-lockfile
 # Copy source files
 COPY web/ .
 
+# Vite build-time env vars — Railway passes values from service variables into
+# --build-arg. Vars must be re-exported via ENV so `pnpm run build` sees them.
+ARG VITE_API_URL
+ARG VITE_OIDC_ISSUER
+ARG VITE_OIDC_CLIENT_ID
+ARG VITE_APP_MODE
+ENV VITE_API_URL=${VITE_API_URL}
+ENV VITE_OIDC_ISSUER=${VITE_OIDC_ISSUER}
+ENV VITE_OIDC_CLIENT_ID=${VITE_OIDC_CLIENT_ID}
+ENV VITE_APP_MODE=${VITE_APP_MODE}
+
 # Build the application
 RUN pnpm run build
 


### PR DESCRIPTION
## Summary
This PR adds support for passing Vite build-time environment variables through Docker build arguments and updates documentation for Dex configuration.

## Key Changes

### Docker Configuration (web/Dockerfile)
- Added ARG declarations for Vite build-time variables: `VITE_API_URL`, `VITE_OIDC_ISSUER`, `VITE_OIDC_CLIENT_ID`, and `VITE_APP_MODE`
- Re-exported these arguments as ENV variables so they're accessible during the `pnpm run build` step
- This enables Railway (and other container platforms) to pass service variables as build arguments that get baked into the compiled application

### Documentation (dex/README.md)
- Added `DEX_EXPAND_ENV=true` to the required service variables table
- Added explanatory note clarifying that `DEX_EXPAND_ENV=true` is required for Dex to properly substitute `${VAR}` placeholders in `config.railway.yaml`
- Included example error message that occurs without this setting to help with troubleshooting

## Implementation Details
The Docker changes follow the pattern of accepting build-time arguments and converting them to environment variables, which is necessary because Vite requires these values at build time (not runtime). This approach allows configuration to be injected during container builds without modifying the source code.

https://claude.ai/code/session_011DpANarsbKGhxkUD7MkUMX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration guide with required environment variable settings for placeholder expansion.

* **Chores**
  * Enhanced build process to support configurable Vite environment variables during Docker image builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->