### PR TITLE
fix: CORS issues by proxying OIDC token exchange through API

### DIFF
--- a/api/src/auth/router.py
+++ b/api/src/auth/router.py
@@ -1,8 +1,11 @@
-from fastapi import APIRouter, Depends
+import httpx
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
 from prisma.models import User
 
 from src.auth.dependencies import get_current_user
 from src.auth.schemas import UserResponse
+from src.config import settings
 
 router = APIRouter()
 
@@ -11,3 +14,27 @@ router = APIRouter()
 async def get_me(current_user: User = Depends(get_current_user)) -> UserResponse:
     """Return the current authenticated user's profile."""
     return UserResponse.model_validate(current_user)
+
+
+@router.post("/token")
+async def proxy_token_exchange(request: Request) -> JSONResponse:
+    """Proxy the OIDC token exchange to Dex to avoid browser CORS issues.
+
+    The frontend sends the authorization code + PKCE verifier here instead
+    of directly to Dex, since Dex doesn't set CORS headers.
+    """
+    body = await request.body()
+    token_url = f"{settings.oidc_issuer}/token"
+
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            token_url,
+            content=body,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=10,
+        )
+
+    return JSONResponse(
+        status_code=response.status_code,
+        content=response.json(),
+    )

--- a/api/src/auth/router.py
+++ b/api/src/auth/router.py
@@ -26,15 +26,26 @@ async def proxy_token_exchange(request: Request) -> JSONResponse:
     body = await request.body()
     token_url = f"{settings.oidc_issuer}/token"
 
-    async with httpx.AsyncClient() as client:
-        response = await client.post(
-            token_url,
-            content=body,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            timeout=10,
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                token_url,
+                content=body,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                timeout=10,
+            )
+    except httpx.HTTPError:
+        return JSONResponse(
+            status_code=502,
+            content={"error": "OIDC provider unreachable"},
         )
+
+    try:
+        content = response.json()
+    except (ValueError, UnicodeDecodeError):
+        content = {"error": response.text}
 
     return JSONResponse(
         status_code=response.status_code,
-        content=response.json(),
+        content=content,
     )

--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -2,6 +2,11 @@ FROM dexidp/dex:v2.39.1
 
 COPY dex/config.railway.yaml /etc/dex/config.yaml
 
+# Enable ${VAR} substitution for DEX_ISSUER and DEX_REDIRECT_URI at startup.
+# Without this, Dex reads placeholders literally and fails with cryptic errors
+# like "malformed bcrypt hash: hashedSecret too short".
+ENV DEX_EXPAND_ENV=true
+
 EXPOSE 5556
 
 CMD ["dex", "serve", "/etc/dex/config.yaml"]

--- a/dex/README.md
+++ b/dex/README.md
@@ -39,27 +39,22 @@ In the Railway project:
 
 ### 2. Set environment variables
 
-On the **dex** service, set:
+On the **dex** service, set only two variables:
 
 | Variable | Example value |
 |---|---|
-| `DEX_EXPAND_ENV` | `true` |
 | `DEX_ISSUER` | `https://dex-open-cis.up.railway.app/dex` |
 | `DEX_REDIRECT_URI` | `https://open-cis-web.up.railway.app/auth/callback` |
-| `DEX_DEMO_ADMIN_HASH` | *(see below)* |
-| `DEX_DEMO_CLINICIAN_HASH` | *(see below)* |
-
-> **Important:** `DEX_EXPAND_ENV=true` is required for Dex to substitute `${VAR}` placeholders in `config.railway.yaml`. Without it, Dex reads the config literally and you'll get errors like `malformed bcrypt hash: hashedSecret too short` (because the literal string `${DEX_DEMO_ADMIN_HASH}` is too short to be a valid bcrypt hash).
 
 `DEX_ISSUER` **must** match the public URL of the Dex service exactly (including `/dex` path).
 
 `DEX_REDIRECT_URI` **must** match the public URL of the `web` service + `/auth/callback`.
 
-### 3. Generate bcrypt password hashes
+> **Note:** `DEX_EXPAND_ENV=true` is already baked into the Dockerfile so Dex can substitute the two placeholders above. Demo password hashes are hardcoded in `config.railway.yaml` (they are not secrets — just one-way hashes of the known demo passwords `admin` and `clinician`).
 
-The demo passwords are hashed with bcrypt (cost 10). The default hashes in `.env.example` correspond to the passwords `admin` and `clinician`. **Replace them for any deployment you share a public URL for.**
+### 3. (Optional) Change the demo passwords
 
-To generate new hashes:
+The default demo accounts are `admin@open-cis.local` (password `admin`) and `clinician@open-cis.local` (password `clinician`). To change them, edit `dex/config.railway.yaml` and replace the bcrypt hashes:
 
 ```bash
 # Python one-liner (requires bcrypt: pip install bcrypt)
@@ -69,7 +64,7 @@ python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(
 htpasswd -bnBC 10 "" 'your-password' | tr -d ':\n'
 ```
 
-Copy each hash directly into the Railway env var panel. Hashes start with `$2b$10$…`. Escape any `$` signs if your deployment tool requires it (Railway's UI does not).
+Paste the result (starts with `$2b$10$…`, exactly 60 characters) into the `hash:` field in `config.railway.yaml`, commit, and redeploy.
 
 ### 4. Configure the `api` service
 

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -18,13 +18,18 @@ staticClients:
 
 enablePasswordDB: true
 
+# Demo password hashes are NOT secrets — they are one-way bcrypt hashes of
+# the public demo passwords "admin" and "clinician". Hardcoding them here
+# avoids env var substitution issues with $ characters and makes deployment
+# a single-step process. For non-demo deployments, replace these hashes and
+# change the passwords documented in README.md.
 staticPasswords:
   - email: admin@open-cis.local
-    hash: "${DEX_DEMO_ADMIN_HASH}"
+    hash: "$2b$10$0ZIL.9k.bCmO9SS.8hOFreuX32kXoTeAMQnUlPeX83aQwmB4/7VdC"
     username: admin
     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 
   - email: clinician@open-cis.local
-    hash: "${DEX_DEMO_CLINICIAN_HASH}"
+    hash: "$2b$10$dnqTBcl8.TMjpfcb7gsZGujBC/HMLxuExPcK4MaVKUwonsK6b9CPm"
     username: clinician
     userID: "6c3f0ed7-6cf4-4d81-9e64-c30f8e5a0f22"

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -6,7 +6,9 @@
  * CORS errors when Dex runs on a different origin (e.g. Railway deployment).
  */
 
-export const OIDC_ISSUER = import.meta.env.VITE_OIDC_ISSUER || 'http://localhost:5556/dex'
+const trimSlash = (s: string) => s.replace(/\/+$/, '')
+
+export const OIDC_ISSUER = trimSlash(import.meta.env.VITE_OIDC_ISSUER || 'http://localhost:5556/dex')
 export const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID || 'open-cis-web'
 export const OIDC_REDIRECT_URI = `${window.location.origin}/auth/callback`
 
@@ -39,7 +41,7 @@ export async function exchangeCodeForToken(
   })
 
   // Proxy through the API backend to avoid CORS issues with Dex
-  const API_URL = import.meta.env.VITE_API_URL || ''
+  const API_URL = trimSlash(import.meta.env.VITE_API_URL || '')
   const response = await fetch(`${API_URL}/api/auth/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },

--- a/web/src/lib/oidc.ts
+++ b/web/src/lib/oidc.ts
@@ -1,36 +1,23 @@
 /**
  * OIDC configuration derived from environment variables.
+ *
+ * Endpoints are derived from the issuer URL using standard OIDC paths rather
+ * than fetching the discovery document from the browser, which would fail with
+ * CORS errors when Dex runs on a different origin (e.g. Railway deployment).
  */
 
 export const OIDC_ISSUER = import.meta.env.VITE_OIDC_ISSUER || 'http://localhost:5556/dex'
 export const OIDC_CLIENT_ID = import.meta.env.VITE_OIDC_CLIENT_ID || 'open-cis-web'
 export const OIDC_REDIRECT_URI = `${window.location.origin}/auth/callback`
 
-interface OidcDiscovery {
-  authorization_endpoint: string
-  token_endpoint: string
-  userinfo_endpoint: string
-  jwks_uri: string
-}
+export const OIDC_AUTH_ENDPOINT = `${OIDC_ISSUER}/auth`
+export const OIDC_TOKEN_ENDPOINT = `${OIDC_ISSUER}/token`
 
 interface TokenResponse {
   access_token: string
   id_token?: string
   token_type: string
   expires_in?: number
-}
-
-let cachedDiscovery: OidcDiscovery | null = null
-
-export async function getOidcDiscovery(): Promise<OidcDiscovery> {
-  if (cachedDiscovery) return cachedDiscovery
-
-  const response = await fetch(`${OIDC_ISSUER}/.well-known/openid-configuration`)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch OIDC discovery: ${response.status}`)
-  }
-  cachedDiscovery = await response.json() as OidcDiscovery
-  return cachedDiscovery
 }
 
 export function generateState(): string {
@@ -43,8 +30,6 @@ export async function exchangeCodeForToken(
   code: string,
   codeVerifier: string,
 ): Promise<string> {
-  const discovery = await getOidcDiscovery()
-
   const body = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
@@ -53,7 +38,9 @@ export async function exchangeCodeForToken(
     code_verifier: codeVerifier,
   })
 
-  const response = await fetch(discovery.token_endpoint, {
+  // Proxy through the API backend to avoid CORS issues with Dex
+  const API_URL = import.meta.env.VITE_API_URL || ''
+  const response = await fetch(`${API_URL}/api/auth/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: body.toString(),

--- a/web/src/pages/auth/LoginPage.vue
+++ b/web/src/pages/auth/LoginPage.vue
@@ -2,7 +2,7 @@
 import { ref } from 'vue'
 import { Loader2, LogIn } from 'lucide-vue-next'
 import { generateCodeVerifier, generateCodeChallenge } from '@/lib/pkce'
-import { getOidcDiscovery, generateState, OIDC_CLIENT_ID, OIDC_REDIRECT_URI } from '@/lib/oidc'
+import { generateState, OIDC_AUTH_ENDPOINT, OIDC_CLIENT_ID, OIDC_REDIRECT_URI } from '@/lib/oidc'
 import DemoCredentialRow from '@/components/auth/DemoCredentialRow.vue'
 
 const isDemoMode = import.meta.env.VITE_APP_MODE === 'demo'
@@ -13,7 +13,6 @@ async function startLogin() {
   loading.value = true
   error.value = null
   try {
-    const discovery = await getOidcDiscovery()
     const codeVerifier = generateCodeVerifier()
     const codeChallenge = await generateCodeChallenge(codeVerifier)
     const state = generateState()
@@ -32,7 +31,7 @@ async function startLogin() {
       state,
     })
 
-    window.location.href = `${discovery.authorization_endpoint}?${params.toString()}`
+    window.location.href = `${OIDC_AUTH_ENDPOINT}?${params.toString()}`
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to start login'
     loading.value = false


### PR DESCRIPTION
## Summary
This PR resolves CORS errors when Dex runs on a different origin (e.g., Railway deployment) by eliminating the need for the browser to fetch the OIDC discovery document and by proxying the token exchange through the backend API.

## Key Changes

- **Frontend OIDC configuration**: Replaced dynamic OIDC discovery document fetching with hardcoded standard OIDC endpoint paths (`/auth` and `/token`), eliminating CORS failures when Dex is on a different origin
- **Token exchange proxy**: Added a new `/api/auth/token` endpoint in the backend that proxies token exchange requests to Dex, avoiding browser CORS restrictions
- **Simplified Dex configuration**: 
  - Removed environment variable placeholders for demo password hashes and moved them directly into `config.railway.yaml` as hardcoded bcrypt hashes
  - Baked `DEX_EXPAND_ENV=true` into the Dockerfile to enable variable substitution for `DEX_ISSUER` and `DEX_REDIRECT_URI`
  - Simplified deployment documentation to require only two environment variables instead of four
- **Updated documentation**: Clarified that demo password hashes are not secrets and provided clearer instructions for changing them

## Implementation Details

- The frontend now uses `OIDC_AUTH_ENDPOINT` and `OIDC_TOKEN_ENDPOINT` constants derived directly from the issuer URL instead of fetching discovery metadata
- The backend token proxy (`POST /api/auth/token`) forwards the authorization code and PKCE verifier to Dex's token endpoint, handling the CORS-sensitive operation server-to-server
- Demo credentials remain unchanged (`admin@open-cis.local`/`admin` and `clinician@open-cis.local`/`clinician`)
- This approach is compatible with standard OIDC implementations that use the conventional `/auth` and `/token` paths

https://claude.ai/code/session_011DpANarsbKGhxkUD7MkUMX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a backend proxy endpoint for OIDC token exchange to centralize authentication requests.

* **Documentation**
  * Simplified setup: only two Dex environment variables required; Docker enables variable substitution by default.
  * Demo password hashes are now provided in the repository config with an optional step to replace them.

* **Refactor**
  * Frontend now uses configured endpoints and routes token exchange through the backend proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->