### PR TITLE
Replace Dex's DEX_EXPAND_ENV with custom entrypoint for Railway

### DIFF
--- a/dex/Dockerfile
+++ b/dex/Dockerfile
@@ -1,12 +1,12 @@
 FROM dexidp/dex:v2.39.1
 
-COPY dex/config.railway.yaml /etc/dex/config.yaml
+# Install config as a template — entrypoint substitutes ${VAR} placeholders
+# at runtime. Dex's own DEX_EXPAND_ENV has been unreliable on Railway.
+COPY dex/config.railway.yaml /etc/dex/config.template.yaml
+COPY dex/entrypoint.sh /entrypoint.sh
 
-# Enable ${VAR} substitution for DEX_ISSUER and DEX_REDIRECT_URI at startup.
-# Without this, Dex reads placeholders literally and fails with cryptic errors
-# like "malformed bcrypt hash: hashedSecret too short".
-ENV DEX_EXPAND_ENV=true
+USER root
+RUN chmod +x /entrypoint.sh
+USER 1001
 
-EXPOSE 5556
-
-CMD ["dex", "serve", "/etc/dex/config.yaml"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -4,7 +4,9 @@ storage:
   type: memory
 
 web:
-  http: 0.0.0.0:5556
+  # Railway assigns a dynamic PORT at deploy time. The Dockerfile sets
+  # DEX_EXPAND_ENV=true so this placeholder is substituted at startup.
+  http: 0.0.0.0:${PORT}
 
 oauth2:
   skipApprovalScreen: true

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -4,8 +4,8 @@ storage:
   type: memory
 
 web:
-  # Railway assigns a dynamic PORT at deploy time. The Dockerfile sets
-  # DEX_EXPAND_ENV=true so this placeholder is substituted at startup.
+  # Railway assigns a dynamic PORT at deploy time. The entrypoint script
+  # substitutes ${PORT} before starting Dex.
   http: 0.0.0.0:${PORT}
 
 oauth2:

--- a/dex/entrypoint.sh
+++ b/dex/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Entrypoint for Dex on Railway.
+#
+# Dex's built-in DEX_EXPAND_ENV feature has been unreliable on Railway,
+# so we do the env var substitution here via sed before starting Dex.
+
+set -e
+
+TEMPLATE=/etc/dex/config.template.yaml
+CONFIG=/tmp/dex-config.yaml
+
+sed \
+  -e "s|\${DEX_ISSUER}|${DEX_ISSUER:-http://localhost:5556/dex}|g" \
+  -e "s|\${DEX_REDIRECT_URI}|${DEX_REDIRECT_URI:-http://localhost:5173/auth/callback}|g" \
+  -e "s|\${PORT}|${PORT:-5556}|g" \
+  "$TEMPLATE" > "$CONFIG"
+
+exec dex serve "$CONFIG"


### PR DESCRIPTION
## Summary
Replace Dex's unreliable `DEX_EXPAND_ENV` feature with a custom shell entrypoint script that performs environment variable substitution before starting Dex. This ensures proper configuration on Railway's dynamic deployment environment.

## Key Changes
- **Added `dex/entrypoint.sh`**: New shell script that uses `sed` to substitute `${DEX_ISSUER}`, `${DEX_REDIRECT_URI}`, and `${PORT}` placeholders in the config template at runtime, with sensible defaults for local development
- **Updated `dex/Dockerfile`**:
  - Changed config file from static `config.yaml` to `config.template.yaml` to clarify it contains placeholders
  - Added entrypoint script with proper permissions (executable, runs as root for chmod, then switches back to user 1001)
  - Removed `DEX_EXPAND_ENV=true` environment variable
  - Replaced `CMD` with `ENTRYPOINT` to invoke the custom script
  - Removed explicit `EXPOSE 5556` (no longer needed with dynamic PORT)
- **Updated `dex/config.railway.yaml`**: Changed hardcoded port `5556` to `${PORT}` placeholder for Railway's dynamic port assignment

## Implementation Details
The entrypoint script uses `sed` for reliable variable substitution before Dex starts, avoiding the cryptic errors that occurred when Dex's built-in expansion failed (e.g., "malformed bcrypt hash: hashedSecret too short"). This approach is more explicit and easier to debug than relying on Dex's internal environment variable handling.

https://claude.ai/code/session_011DpANarsbKGhxkUD7MkUMX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dex deployment now supports runtime configuration via environment variables, allowing customization of port, issuer URL, and redirect URI at deployment time without image rebuilds.

* **Chores**
  * Updated container startup flow to enable dynamic configuration substitution during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->