### PR TITLE
fix: Disable at_hash verification in JWT token validation

### DIFF
--- a/api/src/auth/dependencies.py
+++ b/api/src/auth/dependencies.py
@@ -69,6 +69,7 @@ async def get_current_user(
             jwks,
             algorithms=["RS256"],
             audience=settings.oidc_client_id,
+            options={"verify_at_hash": False},
         )
     except JWTError as e:
         # Log the underlying JWT error so we can diagnose validation failures


### PR DESCRIPTION
## Summary
Disabled the `at_hash` claim verification during JWT token validation in the authentication dependency layer.

## Key Changes
- Added `options={"verify_at_hash": False}` parameter to the JWT decode operation in `get_current_user()`
- This bypasses validation of the `at_hash` claim, which is an optional integrity check for access tokens in OpenID Connect flows

## Implementation Details
The change modifies the JWT decoding configuration to skip verification of the `at_hash` claim. This claim is used to ensure that an access token hasn't been tampered with in certain OAuth/OIDC flows, but its verification can be disabled when not required by the authentication provider or when the claim is not present in tokens.

https://claude.ai/code/session_011DpANarsbKGhxkUD7MkUMX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication validation to reduce unnecessary sign-in failures and increase compatibility with a wider range of tokens, while preserving existing error handling for invalid credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->