### PR TITLE
fix(api): add OIDC_TOKEN_URL for Railway internal networking

### DIFF
--- a/api/src/auth/router.py
+++ b/api/src/auth/router.py
@@ -1,3 +1,5 @@
+import logging
+
 import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
@@ -6,6 +8,8 @@ from prisma.models import User
 from src.auth.dependencies import get_current_user
 from src.auth.schemas import UserResponse
 from src.config import settings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -18,13 +22,9 @@ async def get_me(current_user: User = Depends(get_current_user)) -> UserResponse
 
 @router.post("/token")
 async def proxy_token_exchange(request: Request) -> JSONResponse:
-    """Proxy the OIDC token exchange to Dex to avoid browser CORS issues.
-
-    The frontend sends the authorization code + PKCE verifier here instead
-    of directly to Dex, since Dex doesn't set CORS headers.
-    """
+    """Proxy the OIDC token exchange to Dex to avoid browser CORS issues."""
     body = await request.body()
-    token_url = f"{settings.oidc_issuer}/token"
+    token_url = settings.oidc_token_url or f"{settings.oidc_issuer}/token"
 
     try:
         async with httpx.AsyncClient() as client:
@@ -34,7 +34,8 @@ async def proxy_token_exchange(request: Request) -> JSONResponse:
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 timeout=10,
             )
-    except httpx.HTTPError:
+    except httpx.HTTPError as e:
+        logger.error(f"Token exchange failed: {type(e).__name__}: {e} (url={token_url})")
         return JSONResponse(
             status_code=502,
             content={"error": "OIDC provider unreachable"},

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -15,6 +15,9 @@ class Settings(BaseSettings):
     # OIDC
     oidc_issuer: str = "http://localhost:5556/dex"
     oidc_client_id: str = "open-cis-web"
+    # Server-to-server token endpoint — set on Railway to use internal networking
+    # e.g. http://dex.railway.internal:<port>/dex/token
+    oidc_token_url: str | None = None
 
     # EHRBase (oehrpy client configuration)
     ehrbase_url: str = "http://localhost:8080/ehrbase"


### PR DESCRIPTION
The token exchange proxy was calling Dex via the public URL (https://dex-staging.up.railway.app/dex/token). On Railway, server-to-server calls should use internal networking to avoid routing through the public proxy, which can fail with connection errors.

Add OIDC_TOKEN_URL setting (optional) that overrides the token endpoint derived from OIDC_ISSUER. On Railway, set this to Dex's internal URL:

  OIDC_TOKEN_URL=http://dex.railway.internal:<PORT>/dex/token

where <PORT> is Dex's Railway-assigned port (check Dex service variables for PORT, or use Railway variable reference ${{dex.PORT}}).

Also add error logging with the actual exception type and URL for easier debugging of connectivity failures.

https://claude.ai/code/session_011DpANarsbKGhxkUD7MkUMX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional OIDC token endpoint configuration for custom server-to-server token exchange settings.

* **Bug Fixes**
  * Enhanced error handling and logging for authentication token exchange failures to improve troubleshooting visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->