### PR TITLE
feat: Add login page customization documentation and config

### DIFF
--- a/dex/README.md
+++ b/dex/README.md
@@ -97,6 +97,19 @@ You should see a valid OIDC discovery document with `authorization_endpoint`, `t
 
 Then log into the web app — the Dex login page should appear, accept the demo credentials, and redirect back to the frontend authenticated.
 
+## Login Page Customization
+
+The login page branding is controlled by the `frontend:` block in both `config.yaml` and `config.railway.yaml`:
+
+```yaml
+frontend:
+  issuer: "Open CIS"       # Shown as the provider name
+  theme: "light"           # Built-in: "light" or "coreos"
+  # logoURL: "<public URL>"  # Optional — replaces the default Dex logo
+```
+
+For a full HTML/CSS rebrand, copy Dex's upstream [`web/`](https://github.com/dexidp/dex/tree/v2.39.1/web) directory into this repo (e.g. `dex/web/`), customize `templates/` and `static/`, bake it into `dex/Dockerfile` (`COPY dex/web /srv/dex/web`), and set `frontend.dir: /srv/dex/web` in `config.railway.yaml`.
+
 ## Storage: Memory vs Postgres
 
 The Railway config uses `storage: type: memory`. This is intentional for demo deployments:

--- a/dex/README.md
+++ b/dex/README.md
@@ -39,12 +39,13 @@ In the Railway project:
 
 ### 2. Set environment variables
 
-On the **dex** service, set only two variables:
+On the **dex** service, set:
 
-| Variable | Example value |
-|---|---|
-| `DEX_ISSUER` | `https://dex-open-cis.up.railway.app/dex` |
-| `DEX_REDIRECT_URI` | `https://open-cis-web.up.railway.app/auth/callback` |
+| Variable | Required | Example value |
+|---|---|---|
+| `DEX_ISSUER` | yes | `https://dex-open-cis.up.railway.app/dex` |
+| `DEX_REDIRECT_URI` | yes | `https://open-cis-web.up.railway.app/auth/callback` |
+| `DEX_LOGO_URL` | no | `https://open-cis-web.up.railway.app/favicon.svg` |
 
 `DEX_ISSUER` **must** match the public URL of the Dex service exactly (including `/dex` path).
 
@@ -107,6 +108,8 @@ frontend:
   theme: "light"           # Built-in: "light" or "coreos"
   # logoURL: "<public URL>"  # Optional — replaces the default Dex logo
 ```
+
+On Railway, `logoURL` is populated from the `DEX_LOGO_URL` environment variable at startup (see `entrypoint.sh`). Leave the variable unset to keep Dex's default logo. Locally, edit `config.yaml` directly.
 
 For a full HTML/CSS rebrand, copy Dex's upstream [`web/`](https://github.com/dexidp/dex/tree/v2.39.1/web) directory into this repo (e.g. `dex/web/`), customize `templates/` and `static/`, bake it into `dex/Dockerfile` (`COPY dex/web /srv/dex/web`), and set `frontend.dir: /srv/dex/web` in `config.railway.yaml`.
 

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -11,6 +11,15 @@ web:
 oauth2:
   skipApprovalScreen: true
 
+frontend:
+  issuer: "Open CIS"
+  theme: "light"
+  # logoURL must be reachable from the user's browser. Point at the web
+  # service's favicon or any CDN-hosted image to replace the default Dex logo.
+  # For a full HTML/CSS override, bake a custom theme into dex/Dockerfile and
+  # set `dir:` to that path.
+  # logoURL: "https://<web-host>/favicon.svg"
+
 staticClients:
   - id: open-cis-web
     redirectURIs:

--- a/dex/config.railway.yaml
+++ b/dex/config.railway.yaml
@@ -14,11 +14,9 @@ oauth2:
 frontend:
   issuer: "Open CIS"
   theme: "light"
-  # logoURL must be reachable from the user's browser. Point at the web
-  # service's favicon or any CDN-hosted image to replace the default Dex logo.
-  # For a full HTML/CSS override, bake a custom theme into dex/Dockerfile and
-  # set `dir:` to that path.
-  # logoURL: "https://<web-host>/favicon.svg"
+  # Populated from DEX_LOGO_URL by entrypoint.sh. If unset, the entrypoint
+  # strips this line so Dex falls back to its built-in theme logo.
+  logoURL: "${DEX_LOGO_URL}"
 
 staticClients:
   - id: open-cis-web

--- a/dex/config.yaml
+++ b/dex/config.yaml
@@ -17,6 +17,15 @@ web:
 oauth2:
   skipApprovalScreen: true
 
+frontend:
+  issuer: "Open CIS"
+  theme: "light"
+  # logoURL must be reachable from the user's browser. Uncomment and point at
+  # any publicly served image (e.g. the web app's favicon) to replace the
+  # default Dex logo. For a full HTML/CSS override, also set `dir:` to a
+  # directory containing custom `templates/` and `static/` subdirs.
+  # logoURL: "http://localhost:5173/favicon.svg"
+
 staticClients:
   - id: open-cis-web
     redirectURIs:

--- a/dex/entrypoint.sh
+++ b/dex/entrypoint.sh
@@ -13,6 +13,12 @@ sed \
   -e "s|\${DEX_ISSUER}|${DEX_ISSUER:-http://localhost:5556/dex}|g" \
   -e "s|\${DEX_REDIRECT_URI}|${DEX_REDIRECT_URI:-http://localhost:5173/auth/callback}|g" \
   -e "s|\${PORT}|${PORT:-5556}|g" \
+  -e "s|\${DEX_LOGO_URL}|${DEX_LOGO_URL:-}|g" \
   "$TEMPLATE" > "$CONFIG"
+
+# If DEX_LOGO_URL is unset the substitution leaves `logoURL: ""`. Strip that
+# line so Dex falls back to the theme's default logo rather than rendering a
+# broken <img> with empty src.
+sed -i '/^[[:space:]]*logoURL:[[:space:]]*""[[:space:]]*$/d' "$CONFIG"
 
 exec dex serve "$CONFIG"


### PR DESCRIPTION
## Summary
Added comprehensive documentation and configuration examples for customizing the Dex login page branding, including issuer name, theme selection, and logo customization options.

## Key Changes
- **README.md**: Added new "Login Page Customization" section documenting:
  - How to configure basic branding via the `frontend:` block (issuer, theme, logoURL)
  - Instructions for full HTML/CSS rebranding by copying and customizing Dex's upstream `web/` directory
  - Integration steps for baking custom themes into the Docker image

- **config.railway.yaml**: Added `frontend:` configuration block with:
  - `issuer: "Open CIS"` — sets the provider name displayed to users
  - `theme: "light"` — selects the built-in light theme
  - Commented example for `logoURL` pointing to a web service favicon or CDN-hosted image
  - Guidance on full HTML/CSS overrides via custom Docker builds

- **config.yaml**: Added matching `frontend:` configuration block with:
  - Same issuer and theme settings as Railway config
  - Commented example for `logoURL` pointing to localhost development server
  - Notes on directory-based customization for templates and static assets

## Implementation Details
Both configuration files now include the `frontend:` block with clear comments explaining:
- Browser accessibility requirements for logoURL (must be reachable from user's browser)
- Two customization paths: simple branding (logoURL) vs. full theme override (custom `web/` directory)
- How to integrate custom themes into the Docker build process

https://claude.ai/code/session_01AWKATeRTXuCeWm99ke15k8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide: clarifies required environment variables (DEX_ISSUER, DEX_REDIRECT_URI) and documents optional DEX_LOGO_URL with example.
  * Added frontend configuration guidance: setting issuer name, choosing built-in theme, and supplying a custom logo URL.
  * Described runtime behavior for using or falling back from a provided logo URL and added advanced steps for full HTML/CSS rebranding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->