### PR TITLE
doc: Add OIDC provider health monitoring to system info

### DIFF
--- a/api/src/system/schemas.py
+++ b/api/src/system/schemas.py
@@ -28,6 +28,7 @@ class HealthChecksData(BaseModel):
     database: HealthCheckItem
     ehrbase: HealthCheckItem
     terminology: HealthCheckItem
+    oidc: HealthCheckItem
 
 
 class TemplateInfo(BaseModel):
@@ -86,9 +87,27 @@ class TerminologySection(BaseModel):
     error: SectionError | None = None
 
 
+class OidcData(BaseModel):
+    issuer: str = Field(..., description="Configured OIDC issuer URL")
+    client_id: str = Field(..., description="Configured OIDC client ID")
+    discovery_url: str = Field(..., description="OIDC discovery document URL")
+    jwks_uri: str | None = Field(None, description="JWKS endpoint URL")
+    jwks_cached: bool = Field(False, description="Whether JWKS has been fetched and cached")
+    response_ms: int | None = Field(
+        None, description="Discovery endpoint response time in milliseconds"
+    )
+
+
+class OidcSection(BaseModel):
+    status: str
+    data: OidcData | None = None
+    error: SectionError | None = None
+
+
 class SystemInfoResponse(BaseModel):
     healthChecks: HealthChecksSection
     version: VersionSection
     templates: TemplatesSection
     dbCounts: DbCountsSection
     terminology: TerminologySection
+    oidc: OidcSection

--- a/api/src/system/service.py
+++ b/api/src/system/service.py
@@ -2,9 +2,13 @@ import asyncio
 import importlib.metadata
 import json
 import logging
+import time
 import xml.etree.ElementTree as ET
 from typing import Any
 
+import httpx
+
+from src.auth import dependencies as auth_dependencies
 from src.config import settings
 from src.db.client import prisma
 from src.ehrbase.client import ehrbase_client
@@ -15,6 +19,8 @@ from src.system.schemas import (
     HealthCheckItem,
     HealthChecksData,
     HealthChecksSection,
+    OidcData,
+    OidcSection,
     SectionError,
     SystemInfoResponse,
     TemplateInfo,
@@ -32,25 +38,30 @@ logger = logging.getLogger(__name__)
 class SystemService:
     async def get_system_info(self) -> SystemInfoResponse:
         """Aggregate system health, versions, templates, and data stats."""
-        ehrbase_result, stats_result, terminology_result = await asyncio.gather(
+        ehrbase_result, stats_result, terminology_result, oidc_result = await asyncio.gather(
             self._get_ehrbase_info(),
             self._get_data_stats(),
             self._get_terminology_info(),
+            self._get_oidc_info(),
             return_exceptions=True,
         )
 
         return SystemInfoResponse(
-            healthChecks=self._build_health_checks(ehrbase_result, terminology_result),
+            healthChecks=self._build_health_checks(
+                ehrbase_result, terminology_result, oidc_result
+            ),
             version=self._build_version(ehrbase_result),
             templates=self._build_templates(ehrbase_result),
             dbCounts=self._build_db_counts(stats_result),
             terminology=self._build_terminology(terminology_result),
+            oidc=self._build_oidc(oidc_result),
         )
 
     def _build_health_checks(
         self,
         ehrbase_result: dict[str, Any] | BaseException,
         terminology_result: dict[str, Any] | BaseException | None = None,
+        oidc_result: dict[str, Any] | BaseException | None = None,
     ) -> HealthChecksSection:
         db_connected = prisma.is_connected()
 
@@ -131,7 +142,34 @@ class SystemService:
                     ),
                 )
 
-        items = [api_item, db_item, ehrbase_item, terminology_item]
+        # OIDC health check
+        if isinstance(oidc_result, BaseException) or oidc_result is None:
+            oidc_item = HealthCheckItem(
+                status="error",
+                data=None,
+                error=SectionError(
+                    code="OIDC_UNAVAILABLE",
+                    message="Cannot reach OIDC discovery endpoint",
+                ),
+            )
+        else:
+            oidc_status = oidc_result.get("status", "unavailable")
+            if oidc_status == "available":
+                oidc_item = HealthCheckItem(
+                    status="ok", data={"status": "available"}, error=None
+                )
+            else:
+                oidc_item = HealthCheckItem(
+                    status="error",
+                    data=None,
+                    error=SectionError(
+                        code="OIDC_UNAVAILABLE",
+                        message=oidc_result.get("error")
+                        or "OIDC provider is not responding",
+                    ),
+                )
+
+        items = [api_item, db_item, ehrbase_item, terminology_item, oidc_item]
         error_count = sum(1 for i in items if i.status == "error")
 
         if error_count == 0:
@@ -155,6 +193,7 @@ class SystemService:
                 database=db_item,
                 ehrbase=ehrbase_item,
                 terminology=terminology_item,
+                oidc=oidc_item,
             ),
             error=section_error,
         )
@@ -354,6 +393,85 @@ class SystemService:
 
         status, response_ms = await terminology_client.health_check()
         return {"status": status, "response_ms": response_ms}
+
+    async def _get_oidc_info(self) -> dict[str, Any]:
+        """Probe the OIDC discovery endpoint and report configuration."""
+        discovery_url = (
+            f"{settings.oidc_issuer.rstrip('/')}/.well-known/openid-configuration"
+        )
+        result: dict[str, Any] = {
+            "status": "unavailable",
+            "issuer": settings.oidc_issuer,
+            "client_id": settings.oidc_client_id,
+            "discovery_url": discovery_url,
+            "jwks_uri": settings.oidc_jwks_url,
+            "response_ms": None,
+            "error": None,
+        }
+
+        start = time.monotonic()
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(discovery_url, timeout=5)
+            result["response_ms"] = int((time.monotonic() - start) * 1000)
+            response.raise_for_status()
+            config = response.json()
+            if not result["jwks_uri"]:
+                result["jwks_uri"] = config.get("jwks_uri")
+            result["status"] = "available"
+        except httpx.HTTPError as e:
+            result["error"] = f"{type(e).__name__}: {e}"
+            logger.debug("OIDC discovery probe failed: %s", e)
+        except Exception as e:  # noqa: BLE001
+            result["error"] = f"{type(e).__name__}: {e}"
+            logger.debug("OIDC discovery probe error: %s", e)
+        return result
+
+    def _build_oidc(
+        self, oidc_result: dict[str, Any] | BaseException
+    ) -> OidcSection:
+        if isinstance(oidc_result, BaseException):
+            logger.warning("OIDC info fetch failed: %s", oidc_result)
+            discovery_url = (
+                f"{settings.oidc_issuer.rstrip('/')}/.well-known/openid-configuration"
+            )
+            return OidcSection(
+                status="error",
+                data=OidcData(
+                    issuer=settings.oidc_issuer,
+                    client_id=settings.oidc_client_id,
+                    discovery_url=discovery_url,
+                    jwks_uri=settings.oidc_jwks_url,
+                    jwks_cached=auth_dependencies._jwks_cache is not None,
+                    response_ms=None,
+                ),
+                error=SectionError(
+                    code="OIDC_UNAVAILABLE",
+                    message="Cannot reach OIDC discovery endpoint",
+                ),
+            )
+
+        data = OidcData(
+            issuer=oidc_result["issuer"],
+            client_id=oidc_result["client_id"],
+            discovery_url=oidc_result["discovery_url"],
+            jwks_uri=oidc_result.get("jwks_uri"),
+            jwks_cached=auth_dependencies._jwks_cache is not None,
+            response_ms=oidc_result.get("response_ms"),
+        )
+
+        if oidc_result.get("status") == "available":
+            return OidcSection(status="ok", data=data, error=None)
+
+        return OidcSection(
+            status="error",
+            data=data,
+            error=SectionError(
+                code="OIDC_UNAVAILABLE",
+                message=oidc_result.get("error")
+                or "OIDC provider is not responding",
+            ),
+        )
 
     async def _get_data_stats(self) -> DbCountsData:
         """Fetch counts from the application database."""

--- a/web/src/components/system/SystemHealthDiagram.vue
+++ b/web/src/components/system/SystemHealthDiagram.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { HealthChecksSection, TerminologySection } from '@/types'
+import type { HealthChecksSection, OidcSection, TerminologySection } from '@/types'
 
 defineProps<{
   healthChecks: HealthChecksSection
   terminology: TerminologySection
+  oidc: OidcSection
 }>()
 
 function statusColor(itemStatus: string): string {
@@ -40,6 +41,31 @@ function terminologyHostname(section: TerminologySection): string {
     return url.hostname
   } catch {
     return section.data.url
+  }
+}
+
+function oidcStatusColor(status: string): string {
+  if (status === 'ok') return 'bg-green-500'
+  if (status === 'partial') return 'bg-yellow-500'
+  return 'bg-red-500'
+}
+
+function oidcLabel(section: OidcSection): string {
+  if (section.status === 'ok') return 'Available'
+  if (section.status === 'partial') return 'Degraded'
+  return 'Unavailable'
+}
+
+function oidcHostname(section: OidcSection): string {
+  if (!section.data?.issuer) return 'Not configured'
+  try {
+    const url = new URL(section.data.issuer)
+    if (['localhost', '127.0.0.1'].includes(url.hostname)) {
+      return `${url.hostname} (Dex)`
+    }
+    return url.hostname
+  } catch {
+    return section.data.issuer
   }
 }
 </script>
@@ -107,6 +133,33 @@ function terminologyHostname(section: TerminologySection): string {
         </div>
       </div>
 
+      <!-- Connection line from API down to OIDC row -->
+      <div class="flex items-center gap-3">
+        <div class="min-w-[140px]" />
+        <span class="invisible">&rarr;</span>
+        <div class="min-w-[140px] flex justify-center">
+          <span class="text-muted-foreground">&darr;</span>
+        </div>
+      </div>
+
+      <!-- Row 3: OIDC Provider -->
+      <div class="flex items-center gap-3">
+        <div class="min-w-[140px]" />
+        <span class="invisible">&rarr;</span>
+        <div class="flex items-center gap-2 rounded-md border px-4 py-3 min-w-[140px]">
+          <span class="h-2.5 w-2.5 rounded-full shrink-0" :class="oidcStatusColor(oidc.status)" />
+          <div>
+            <p class="text-sm font-medium">OIDC Provider</p>
+            <p class="text-xs text-muted-foreground">{{ oidcLabel(oidc) }}</p>
+          </div>
+        </div>
+        <span class="text-muted-foreground text-xs">&larr;</span>
+        <div class="text-xs text-muted-foreground">
+          <p>{{ oidcHostname(oidc) }}</p>
+          <p v-if="oidc.data?.response_ms != null">{{ oidc.data.response_ms }}ms</p>
+        </div>
+      </div>
+
       <!-- Connection line from API down to Terminology row -->
       <div class="flex items-center gap-3">
         <div class="min-w-[140px]" />
@@ -116,7 +169,7 @@ function terminologyHostname(section: TerminologySection): string {
         </div>
       </div>
 
-      <!-- Row 3: Terminology Server -->
+      <!-- Row 4: Terminology Server -->
       <div class="flex items-center gap-3">
         <div class="min-w-[140px]" />
         <span class="invisible">&rarr;</span>
@@ -144,6 +197,7 @@ function terminologyHostname(section: TerminologySection): string {
           { name: 'App Database', status: healthChecks.data.database.status, desc: 'PostgreSQL', label: statusLabel(healthChecks.data.database) },
           { name: 'EHRBase', status: healthChecks.data.ehrbase.status, desc: 'openEHR CDR', label: statusLabel(healthChecks.data.ehrbase) },
           { name: 'EHRBase DB', status: healthChecks.data.ehrbase.status, desc: 'PostgreSQL', label: statusLabel(healthChecks.data.ehrbase) },
+          { name: 'OIDC Provider', status: oidc.status === 'ok' ? 'ok' as const : 'error' as const, desc: oidcHostname(oidc), label: oidcLabel(oidc) },
           { name: 'Terminology', status: terminology.status === 'ok' ? 'ok' as const : 'error' as const, desc: terminologyHostname(terminology), label: terminologyLabel(terminology) },
         ]"
         :key="item.name"

--- a/web/src/pages/SystemInfoPage.vue
+++ b/web/src/pages/SystemInfoPage.vue
@@ -72,6 +72,7 @@ onUnmounted(() => {
       <SystemHealthDiagram
         :health-checks="store.systemInfo.healthChecks"
         :terminology="store.systemInfo.terminology"
+        :oidc="store.systemInfo.oidc"
       />
 
       <!-- Version Info + Data Stats -->
@@ -111,6 +112,44 @@ onUnmounted(() => {
               <span class="text-muted-foreground">Response</span>
               <span class="font-mono">{{ store.systemInfo.terminology.data.response_ms }}ms</span>
             </div>
+          </div>
+          <!-- OIDC Provider Info -->
+          <div v-if="store.systemInfo.oidc.data" class="border-t pt-3 mt-3 space-y-2">
+            <h3 class="text-sm font-medium">OpenID Connect</h3>
+            <div class="flex justify-between text-sm">
+              <span class="text-muted-foreground">Issuer</span>
+              <span class="font-mono text-xs truncate max-w-[220px]" :title="store.systemInfo.oidc.data.issuer">
+                {{ store.systemInfo.oidc.data.issuer }}
+              </span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-muted-foreground">Client ID</span>
+              <span class="font-mono text-xs">{{ store.systemInfo.oidc.data.client_id }}</span>
+            </div>
+            <div v-if="store.systemInfo.oidc.data.jwks_uri" class="flex justify-between text-sm">
+              <span class="text-muted-foreground">JWKS</span>
+              <span class="font-mono text-xs truncate max-w-[220px]" :title="store.systemInfo.oidc.data.jwks_uri">
+                {{ store.systemInfo.oidc.data.jwks_uri }}
+              </span>
+            </div>
+            <div class="flex justify-between text-sm">
+              <span class="text-muted-foreground">JWKS Cache</span>
+              <span
+                class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                :class="store.systemInfo.oidc.data.jwks_cached
+                  ? 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-300'
+                  : 'bg-muted text-muted-foreground'"
+              >
+                {{ store.systemInfo.oidc.data.jwks_cached ? 'Cached' : 'Not cached' }}
+              </span>
+            </div>
+            <div v-if="store.systemInfo.oidc.data.response_ms != null" class="flex justify-between text-sm">
+              <span class="text-muted-foreground">Discovery</span>
+              <span class="font-mono">{{ store.systemInfo.oidc.data.response_ms }}ms</span>
+            </div>
+            <p v-if="store.systemInfo.oidc.error" class="text-xs text-destructive">
+              {{ store.systemInfo.oidc.error.message }}
+            </p>
           </div>
         </div>
 

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -97,6 +97,7 @@ export interface HealthChecksData {
   database: HealthCheckItem
   ehrbase: HealthCheckItem
   terminology: HealthCheckItem
+  oidc: HealthCheckItem
 }
 
 export interface HealthChecksSection {
@@ -153,12 +154,28 @@ export interface TerminologySection {
   error: SectionError | null
 }
 
+export interface OidcData {
+  issuer: string
+  client_id: string
+  discovery_url: string
+  jwks_uri: string | null
+  jwks_cached: boolean
+  response_ms: number | null
+}
+
+export interface OidcSection {
+  status: 'ok' | 'partial' | 'error'
+  data: OidcData | null
+  error: SectionError | null
+}
+
 export interface SystemInfo {
   healthChecks: HealthChecksSection
   version: VersionSection
   templates: TemplatesSection
   dbCounts: DbCountsSection
   terminology: TerminologySection
+  oidc: OidcSection
 }
 
 // Re-export vitals types


### PR DESCRIPTION
## Summary
This PR adds OpenID Connect (OIDC) provider health monitoring and configuration visibility to the system information endpoint and UI. The system now probes the OIDC discovery endpoint, reports configuration details, and displays OIDC provider status alongside other system dependencies.

## Key Changes

**Backend (API)**
- Added `_get_oidc_info()` method to probe the OIDC discovery endpoint (`.well-known/openid-configuration`) with a 5-second timeout
- Added `_build_oidc()` method to construct OIDC section response with status, configuration data, and error details
- Integrated OIDC health check into the main `get_system_info()` aggregation using `asyncio.gather()`
- Updated `_build_health_checks()` to include OIDC provider status in the health checks data
- Added new `OidcData` and `OidcSection` Pydantic models to schemas
- Updated `HealthChecksData` to include OIDC health check item
- Updated `SystemInfoResponse` to include OIDC section

**Frontend (Web)**
- Updated `SystemHealthDiagram.vue` to display OIDC provider status in the system architecture diagram
- Added helper functions: `oidcStatusColor()`, `oidcLabel()`, and `oidcHostname()` for OIDC-specific formatting
- Added OIDC provider row to the visual diagram with connection lines
- Updated the summary table to include OIDC provider status
- Updated `SystemInfoPage.vue` to pass OIDC data to the health diagram component
- Added detailed OIDC configuration display section showing issuer, client ID, JWKS URI, cache status, and discovery response time
- Updated TypeScript types to include `OidcData` and `OidcSection` interfaces

## Implementation Details

- OIDC discovery probing is performed asynchronously in parallel with other health checks
- Response time is measured using `time.monotonic()` for accuracy
- JWKS URI is populated from discovery endpoint if not explicitly configured
- JWKS cache status is tracked via `auth_dependencies._jwks_cache`
- Errors during discovery are caught and reported without blocking other health checks
- The UI intelligently extracts hostname from issuer URL and identifies local Dex instances
- All OIDC configuration is displayed even when the provider is unavailable, aiding in troubleshooting

https://claude.ai/code/session_01F3oTrGbKsGye4B9inpf1bB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect (OIDC) provider monitoring to system health checks
  * System info page now displays OIDC configuration details including issuer, client ID, JWKS URI, caching status, and discovery response time
  * OIDC errors and status are reported within the system information interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->